### PR TITLE
Renamed namespace to github.com/arangodb-helper/arangodb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changes from version 0.6.0 to master 
 
+- Renamed github repository from github.com/arangodb-helper/ArangoDBStarter to github.com/arangodb-helper/arangodb.
 - When an `--sslKeyFile` (or `--sslAutoKeyFile`) argument is given, the starter will serve it's API over TLS using the same certificate as the database server(s).
 - Starter will detect the name of the docker container is it running in automatically (if running in docker and not set using `--dockerContainer`)
 - Changed default master port from 4000 to 8528. That results in a coordinator/single server to be available on well known port 8529

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROJECT := ArangoDBStarter
+PROJECT := arangodb
 SCRIPTDIR := $(shell pwd)
 ROOTDIR := $(shell cd $(SCRIPTDIR) && pwd)
 VERSION := $(shell cat $(ROOTDIR)/VERSION)
@@ -12,7 +12,7 @@ GOBUILDDIR := $(SCRIPTDIR)/.gobuild
 SRCDIR := $(SCRIPTDIR)
 BINDIR := $(ROOTDIR)/bin
 
-ORGPATH := github.com/arangodb
+ORGPATH := github.com/arangodb-helper
 ORGDIR := $(GOBUILDDIR)/src/$(ORGPATH)
 REPONAME := $(PROJECT)
 REPODIR := $(ORGDIR)/$(REPONAME)

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@ Starting an ArangoDB cluster the easy way
 =========================================
 Downloading Releases
 --------------------
-You can download precompiled ArangoDBStarter binaries via [the github releases page](https://github.com/arangodb-helper/ArangoDBStarter/releases).
+You can download precompiled `arangodb` binaries via [the github releases page](https://github.com/arangodb-helper/arangodb/releases).
 
 Building
 --------
 
-If you want to compile ArangoDBStarter yourselves just do
+If you want to compile `arangodb` yourselves just do
 
 ```
 make local
@@ -65,9 +65,9 @@ other installation files automatically. If this fails, use the
 
 Running in Docker 
 -----------------
-You can run ArangoDBStarter using our ready made docker container. 
+You can run `arangodb` using our ready made docker container. 
 
-When using ArangoDBStarter in a Docker container it will also run all 
+When using `arangodb` in a Docker container it will also run all 
 servers in a docker using the `arangodb/arangodb:latest` docker image.
 If you wish to run a specific docker image for the servers, specify it using
 the `--docker` argument.

--- a/main.go
+++ b/main.go
@@ -35,8 +35,8 @@ import (
 	"syscall"
 	"time"
 
-	_ "github.com/arangodb/ArangoDBStarter/client"
-	service "github.com/arangodb/ArangoDBStarter/service"
+	_ "github.com/arangodb-helper/arangodb/client"
+	service "github.com/arangodb-helper/arangodb/service"
 	homedir "github.com/mitchellh/go-homedir"
 	logging "github.com/op/go-logging"
 	"github.com/pkg/errors"

--- a/service/server.go
+++ b/service/server.go
@@ -33,7 +33,7 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"github.com/arangodb/ArangoDBStarter/client"
+	"github.com/arangodb-helper/arangodb/client"
 )
 
 var (

--- a/test/server_util.go
+++ b/test/server_util.go
@@ -31,8 +31,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/arangodb/ArangoDBStarter/client"
-	"github.com/arangodb/ArangoDBStarter/service"
+	"github.com/arangodb-helper/arangodb/client"
+	"github.com/arangodb-helper/arangodb/service"
 )
 
 const (

--- a/test/util.go
+++ b/test/util.go
@@ -35,7 +35,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/arangodb/ArangoDBStarter/client"
+	"github.com/arangodb-helper/arangodb/client"
 	shell "github.com/kballard/go-shellquote"
 	"github.com/pkg/errors"
 	"github.com/shavac/gexpect"

--- a/tools/release/release.go
+++ b/tools/release/release.go
@@ -49,7 +49,7 @@ func init() {
 	flag.StringVar(&releaseType, "type", "patch", "Type of release to build (major|minor|patch)")
 	flag.StringVar(&ghRelease, "github-release", ".gobuild/bin/github-release", "Full path of github-release tool")
 	flag.StringVar(&ghUser, "github-user", "arangodb-helper", "Github account name to create release in")
-	flag.StringVar(&ghRepo, "github-repo", "ArangoDBStarter", "Github repository name to create release in")
+	flag.StringVar(&ghRepo, "github-repo", "arangodb", "Github repository name to create release in")
 	flag.StringVar(&binFolder, "bin-folder", "./bin", "Folder containing binaries")
 }
 


### PR DESCRIPTION
To reflect the renamed github repository.