### PR TITLE
Use docker image name that is used to run the starter container

### DIFF
--- a/service/arangodb.go
+++ b/service/arangodb.go
@@ -74,6 +74,7 @@ type Config struct {
 	DockerContainerName string // Name of the container running this process
 	DockerEndpoint      string // Where to reach the docker daemon
 	DockerImage         string // Name of Arangodb docker image
+	DockerStarterImage  string
 	DockerUser          string
 	DockerGCDelay       time.Duration
 	DockerNetworkMode   string

--- a/service/master.go
+++ b/service/master.go
@@ -106,7 +106,7 @@ func (s *Service) showSlaveStartCommands(runner Runner) {
 		if s.announcePort != s.MasterPort {
 			port = strconv.Itoa(s.announcePort)
 		}
-		fmt.Println(runner.CreateStartArangodbCommand(s.DataDir, index, s.OwnAddress, port))
+		fmt.Println(runner.CreateStartArangodbCommand(s.DataDir, index, s.OwnAddress, port, s.DockerStarterImage))
 		fmt.Println()
 	}
 }

--- a/service/runner.go
+++ b/service/runner.go
@@ -41,7 +41,7 @@ type Runner interface {
 	Start(command string, args []string, volumes []Volume, ports []int, containerName, serverDir string) (Process, error)
 
 	// Create a command that a user should use to start a slave arangodb instance.
-	CreateStartArangodbCommand(myDataDir string, index int, masterIP string, masterPort string) string
+	CreateStartArangodbCommand(myDataDir string, index int, masterIP, masterPort, starterImageName string) string
 
 	// Cleanup after all processes are dead and have been cleaned themselves
 	Cleanup() error

--- a/service/runner_docker.go
+++ b/service/runner_docker.go
@@ -267,7 +267,7 @@ func (r *dockerRunner) pullImage(image string) error {
 	return nil
 }
 
-func (r *dockerRunner) CreateStartArangodbCommand(myDataDir string, index int, masterIP string, masterPort string) string {
+func (r *dockerRunner) CreateStartArangodbCommand(myDataDir string, index int, masterIP, masterPort, starterImageName string) string {
 	addr := masterIP
 	hostPort := DefaultMasterPort + (portOffsetIncrement * (index - 1))
 	if masterPort != "" {
@@ -284,7 +284,7 @@ func (r *dockerRunner) CreateStartArangodbCommand(myDataDir string, index int, m
 	lines := []string{
 		fmt.Sprintf("docker volume create arangodb%d &&", index),
 		fmt.Sprintf("docker run -it --name=adb%d --rm %s -v arangodb%d:/data", index, netArgs, index),
-		fmt.Sprintf("-v /var/run/docker.sock:/var/run/docker.sock arangodb/arangodb-starter"),
+		fmt.Sprintf("-v /var/run/docker.sock:/var/run/docker.sock %s", starterImageName),
 		fmt.Sprintf("--starter.address=%s --starter.join=%s", masterIP, addr),
 	}
 	return strings.Join(lines, " \\\n    ")

--- a/service/runner_process.go
+++ b/service/runner_process.go
@@ -98,7 +98,7 @@ func (r *processRunner) Start(command string, args []string, volumes []Volume, p
 	return &process{log: r.log, p: c.Process, isChild: true}, nil
 }
 
-func (r *processRunner) CreateStartArangodbCommand(myDataDir string, index int, masterIP string, masterPort string) string {
+func (r *processRunner) CreateStartArangodbCommand(myDataDir string, index int, masterIP, masterPort, starterImageName string) string {
 	if masterIP == "" {
 		masterIP = "127.0.0.1"
 	}


### PR DESCRIPTION
fixes #52 

The recommended commands to start other starters (when using docker) now shows the image that was use to start the container running the first starter.

In this snippet,
```
docker volume create arangodb2 && \
    docker run -it --name=adb2 --rm -p 8533:8528 -v arangodb2:/data \
    -v /var/run/docker.sock:/var/run/docker.sock arangodb/arangodb-starter:latest \
    --starter.address=192.168.10.11 --starter.join=192.168.10.11
```

the `arangodb/arangodb-starter:latest` part is now read from the docker container info of the running container.