### PR TITLE
Adding pass through options (wip)

### DIFF
--- a/main.go
+++ b/main.go
@@ -169,6 +169,9 @@ func init() {
 			fullPrefix := "--" + ptPrefix.Prefix + "."
 			if strings.HasPrefix(a, fullPrefix) {
 				option := getPassthroughOption(a, fullPrefix)
+				if option.IsForbidden() {
+					log.Fatalf("Option '%s' is essential to the starters behavior and cannot be overwritten.", option.FormattedOptionName())
+				}
 				f.StringSliceVar(ptPrefix.FieldSelector(option), ptPrefix.Prefix+"."+option.Name, nil, fmt.Sprintf("Passed through to %s as --%s", ptPrefix.Usage, option.Name))
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -93,6 +93,7 @@ var (
 	dockerNetHost        bool // Deprecated
 	dockerNetworkMode    string
 	dockerPrivileged     bool
+	passthroughOptions   = make(map[string]*service.PassthroughOption)
 
 	maskAny = errors.WithStack
 )
@@ -141,6 +142,37 @@ func init() {
 	f.StringVar(&sslAutoOrganization, "ssl.auto-organization", "ArangoDB", "Organization name put into self-signed certificate. See --ssl.auto-key")
 
 	f.SetNormalizeFunc(normalizeOptionNames)
+
+	// Setup passthrough arguments
+	getPassthroughOption := func(arg, prefix string) *service.PassthroughOption {
+		arg = arg[len(prefix):]
+		name := strings.TrimSpace(strings.Split(arg, "=")[0])
+		result, found := passthroughOptions[name]
+		if !found {
+			result = &service.PassthroughOption{Name: name}
+			passthroughOptions[name] = result
+		}
+		return result
+	}
+	passthroughPrefixes := []struct {
+		Prefix        string
+		Usage         string
+		FieldSelector func(option *service.PassthroughOption) *[]string
+	}{
+		{"all", "all server instances", func(option *service.PassthroughOption) *[]string { return &option.Values.All }},
+		{"coordinators", "all coordinator instances", func(option *service.PassthroughOption) *[]string { return &option.Values.Coordinators }},
+		{"dbservers", "all dbserver instances", func(option *service.PassthroughOption) *[]string { return &option.Values.DBServers }},
+		{"agents", "all agent instances", func(option *service.PassthroughOption) *[]string { return &option.Values.Agents }},
+	}
+	for _, a := range os.Args {
+		for _, ptPrefix := range passthroughPrefixes {
+			fullPrefix := "--" + ptPrefix.Prefix + "."
+			if strings.HasPrefix(a, fullPrefix) {
+				option := getPassthroughOption(a, fullPrefix)
+				f.StringSliceVar(ptPrefix.FieldSelector(option), ptPrefix.Prefix+"."+option.Name, nil, fmt.Sprintf("Passed through to %s as --%s", ptPrefix.Usage, option.Name))
+			}
+		}
+	}
 }
 
 var (
@@ -384,7 +416,7 @@ func cmdMainRun(cmd *cobra.Command, args []string) {
 	go handleSignal(sigChannel, cancel)
 
 	// Create service
-	service, err := service.NewService(log, service.Config{
+	serviceConfig := service.Config{
 		ID:                   id,
 		Mode:                 mode,
 		AgencySize:           agencySize,
@@ -416,7 +448,11 @@ func cmdMainRun(cmd *cobra.Command, args []string) {
 		DockerPrivileged:     dockerPrivileged,
 		ProjectVersion:       projectVersion,
 		ProjectBuild:         projectBuild,
-	}, false)
+	}
+	for _, ptOpt := range passthroughOptions {
+		serviceConfig.PassthroughOptions = append(serviceConfig.PassthroughOptions, *ptOpt)
+	}
+	service, err := service.NewService(log, serviceConfig, false)
 	if err != nil {
 		log.Fatalf("Failed to create service: %#v", err)
 	}

--- a/service/arangodb.go
+++ b/service/arangodb.go
@@ -86,70 +86,6 @@ type Config struct {
 	ProjectBuild   string
 }
 
-type PassthroughOption struct {
-	Name   string
-	Values struct {
-		All          []string
-		Coordinators []string
-		DBServers    []string
-		Agents       []string
-	}
-}
-
-// valueForServerType returns the value for the given option for a specific server type.
-// If no value is given for the specific server type, any value for `all` is returned.
-func (o *PassthroughOption) valueForServerType(serverType ServerType) []string {
-	var result []string
-	switch serverType {
-	case ServerTypeSingle:
-		result = o.Values.All
-	case ServerTypeCoordinator:
-		result = o.Values.Coordinators
-	case ServerTypeDBServer:
-		result = o.Values.DBServers
-	case ServerTypeAgent:
-		result = o.Values.Agents
-	}
-	if len(result) > 0 {
-		return result
-	}
-	return o.Values.All
-}
-
-// formattedOptionName returns the option ready to be used in a command line argument,
-// prefixed with `--`.
-func (o *PassthroughOption) formattedOptionName() string {
-	return "--" + o.Name
-}
-
-// sectionName returns the name of the configuration section this option belongs to.
-func (o *PassthroughOption) sectionName() string {
-	return strings.SplitN(o.Name, ".", 2)[0]
-}
-
-// sectionKey returns the name of this option within its configuration section.
-func (o *PassthroughOption) sectionKey() string {
-	parts := strings.SplitN(o.Name, ".", 2)
-	if len(parts) > 1 {
-		return parts[1]
-	}
-	return ""
-}
-
-func (c *Config) passthroughOptionValuesForServerType(name string, serverType ServerType) []string {
-	for _, ptOpt := range c.PassthroughOptions {
-		if ptOpt.Name != name {
-			continue
-		}
-		values := ptOpt.valueForServerType(serverType)
-		if len(values) > 0 {
-			return values
-		}
-		return nil
-	}
-	return nil
-}
-
 // Service implements the actual starter behavior of the ArangoDB starter.
 type Service struct {
 	Config
@@ -551,7 +487,7 @@ func (s *Service) makeBaseArgs(myHostDir, myContainerDir string, myAddress strin
 		}
 		// Append all values
 		for _, value := range values {
-			args = append(args, ptOpt.formattedOptionName(), value)
+			args = append(args, ptOpt.FormattedOptionName(), value)
 		}
 	}
 	return

--- a/service/arangodb.go
+++ b/service/arangodb.go
@@ -482,7 +482,7 @@ func (s *Service) makeBaseArgs(myHostDir, myContainerDir string, myAddress strin
 		// Look for overrides of configuration sections
 		if section := config.FindSection(ptOpt.sectionName()); section != nil {
 			if confValue, found := section.Settings[ptOpt.sectionKey()]; found {
-				s.log.Warningf("Pass through option %s conflicts with automatically generated configuration option with value '%s'", ptOpt.Name, confValue)
+				s.log.Warningf("Pass through option %s overrides generated configuration option with value '%s'", ptOpt.Name, confValue)
 			}
 		}
 		// Append all values

--- a/service/config.go
+++ b/service/config.go
@@ -56,6 +56,17 @@ func (cf configFile) WriteTo(w io.Writer) (int64, error) {
 	return x, nil
 }
 
+// FindSection searches for a section with given name and returns it.
+// If not found, nil is returned.
+func (cf configFile) FindSection(sectionName string) *configSection {
+	for _, sect := range cf {
+		if sect.Name == sectionName {
+			return sect
+		}
+	}
+	return nil
+}
+
 type configSection struct {
 	Name     string
 	Settings map[string]string

--- a/service/passthrough.go
+++ b/service/passthrough.go
@@ -47,7 +47,6 @@ var (
 		"cluster.my-role",
 		"cluster.my-local-info",
 		"database.directory",
-		"foxx.queues",
 		"javascript.startup-directory",
 		"javascript.app-path",
 		"server.endpoint",

--- a/service/passthrough.go
+++ b/service/passthrough.go
@@ -1,0 +1,124 @@
+//
+// DISCLAIMER
+//
+// Copyright 2017 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+// Author Ewout Prangsma
+//
+
+package service
+
+import "strings"
+
+type PassthroughOption struct {
+	Name   string
+	Values struct {
+		All          []string
+		Coordinators []string
+		DBServers    []string
+		Agents       []string
+	}
+}
+
+var (
+	// forbiddenPassthroughOptions holds a list of options that are not allowed to be overriden.
+	forbiddenPassthroughOptions = []string{
+		"agency.activate",
+		"agency.endpoint",
+		"agency.my-address",
+		"agency.size",
+		"agency.supervision",
+		"cluster.agency-endpoint",
+		"cluster.my-address",
+		"cluster.my-role",
+		"cluster.my-local-info",
+		"database.directory",
+		"foxx.queues",
+		"javascript.startup-directory",
+		"javascript.app-path",
+		"server.endpoint",
+		"server.authentication",
+		"server.jwt-secret",
+		"server.storage-engine",
+		"ssl.cafile",
+		"ssl.keyfile",
+	}
+)
+
+// valueForServerType returns the value for the given option for a specific server type.
+// If no value is given for the specific server type, any value for `all` is returned.
+func (o *PassthroughOption) valueForServerType(serverType ServerType) []string {
+	var result []string
+	switch serverType {
+	case ServerTypeSingle:
+		result = o.Values.All
+	case ServerTypeCoordinator:
+		result = o.Values.Coordinators
+	case ServerTypeDBServer:
+		result = o.Values.DBServers
+	case ServerTypeAgent:
+		result = o.Values.Agents
+	}
+	if len(result) > 0 {
+		return result
+	}
+	return o.Values.All
+}
+
+// IsForbidden returns true if the option cannot be overwritten.
+func (o *PassthroughOption) IsForbidden() bool {
+	for _, x := range forbiddenPassthroughOptions {
+		if x == o.Name {
+			return true
+		}
+	}
+	return false
+}
+
+// FormattedOptionName returns the option ready to be used in a command line argument,
+// prefixed with `--`.
+func (o *PassthroughOption) FormattedOptionName() string {
+	return "--" + o.Name
+}
+
+// sectionName returns the name of the configuration section this option belongs to.
+func (o *PassthroughOption) sectionName() string {
+	return strings.SplitN(o.Name, ".", 2)[0]
+}
+
+// sectionKey returns the name of this option within its configuration section.
+func (o *PassthroughOption) sectionKey() string {
+	parts := strings.SplitN(o.Name, ".", 2)
+	if len(parts) > 1 {
+		return parts[1]
+	}
+	return ""
+}
+
+func (c *Config) passthroughOptionValuesForServerType(name string, serverType ServerType) []string {
+	for _, ptOpt := range c.PassthroughOptions {
+		if ptOpt.Name != name {
+			continue
+		}
+		values := ptOpt.valueForServerType(serverType)
+		if len(values) > 0 {
+			return values
+		}
+		return nil
+	}
+	return nil
+}

--- a/test/passthrough_test.go
+++ b/test/passthrough_test.go
@@ -1,0 +1,45 @@
+//
+// DISCLAIMER
+//
+// Copyright 2017 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+// Author Ewout Prangsma
+//
+
+package test
+
+import (
+	"os"
+	"regexp"
+	"testing"
+	"time"
+)
+
+// TestPassthroughConflict runs `arangodb --starter.local --all.ssl.keyfile=foo`
+func TestPassthroughConflict(t *testing.T) {
+	needTestMode(t, testModeProcess)
+	dataDir := SetUniqueDataDir(t)
+	defer os.RemoveAll(dataDir)
+
+	child := Spawn(t, "${STARTER} --starter.local --all.ssl.keyfile=foo")
+	defer child.Close()
+
+	expr := regexp.MustCompile("is essential to the starters behavior and cannot be overwritten")
+	if _, err := child.ExpectTimeout(time.Second*15, expr); err != nil {
+		t.Errorf("Expected errors message, got %#v", err)
+	}
+}


### PR DESCRIPTION
This PR adds a way to passthrough options from the starter to all (or some) of the `arangod` instances it starts.

Options that have the following prefixes will be passed through:

- `--all.x.y=value` will be passed through to all server instances as `--x.y=value`
- `--coordinators.x.y=value` will be passed through to all coordinator instances as `--x.y=value`
- `--dbservers.x.y=value` will be passed through to all dbserver instances as `--x.y=value`
- `--agents.x.y=value` will be passed through to all agent instances as `--x.y=value`