### PR TITLE
Add folder containing executable to search path for `arangod`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Changes from version 0.7.1 to 0.7.2
+
+- Added path containing starter executable to search path for `arangod`.
+
 # Changes from version 0.7.0 to 0.7.1
 
 - Added `--rocksdb.encryption-keyfile` option.

--- a/main.go
+++ b/main.go
@@ -281,6 +281,13 @@ func findExecutable() {
 			"/usr/sbin/arangod",
 		)
 	}
+	// Add local folder to search path
+	if exePath, err := os.Executable(); err == nil {
+		folder := filepath.Dir(exePath)
+		pathList = append(pathList, filepath.Join(folder, "arangod"+filepath.Ext(exePath)))
+	}
+
+	// Search to search path for the first path that exists.
 	for _, p := range pathList {
 		if _, e := os.Stat(filepath.Clean(filepath.FromSlash(p))); e == nil || !os.IsNotExist(e) {
 			arangodPath, _ = filepath.Abs(filepath.FromSlash(p))


### PR DESCRIPTION
This PR adds the folder containing the starter executable to the search path for `arangod`.