### PR TITLE
Start & stop detached starter 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Changes from version 0.7.2 to master
+
+- Added `start` command to run starter in detached mode.
+- Added `stop` command to stop a running starter using its HTTP API.
+
 # Changes from version 0.7.1 to 0.7.2
 
 - Added path containing starter executable to search path for `arangod`.

--- a/README.md
+++ b/README.md
@@ -145,6 +145,31 @@ docker run -it --name=adb --rm -p 8528:8528 \
     --starter.mode=single
 ```
 
+Starting & stopping in detached mode 
+------------------------------------
+
+If you want the starter to detach and run as a background process, use the `start` 
+command. This is typically used by developers running tests only.
+
+```
+arangodb start --starter.local=true [--starter.wait]
+```
+
+This command will make the starter run another starter process in the background 
+(that starts all ArangoDB servers), wait for it's HTTP API to be available and
+then exit. The starter that was started in the background will keep running until you stop it.
+
+The `--starter.wait` option makes the `start` command wait until all ArangoDB server 
+are really up, before ending the master process.
+
+To stop a starter use this command.
+
+```
+arangodb stop
+```
+
+Make sure to match the arguments given to start the starter (`--starter.port` & `--ssl.*`).
+
 Common options 
 --------------
 

--- a/service/arangodb.go
+++ b/service/arangodb.go
@@ -245,8 +245,8 @@ func (s *Service) serverExecutable() string {
 	return s.ArangodPath
 }
 
-// testInstance checks the `up` status of an arangod server instance.
-func (s *Service) testInstance(ctx context.Context, address string, port int) (up bool, version string, cancelled bool) {
+// TestInstance checks the `up` status of an arangod server instance.
+func (s *Service) TestInstance(ctx context.Context, address string, port int) (up bool, version string, cancelled bool) {
 	instanceUp := make(chan string)
 	go func() {
 		client := &http.Client{Timeout: time.Second * 10}
@@ -544,7 +544,7 @@ func (s *Service) startArangod(runner Runner, myHostAddress string, serverType S
 	if p != nil {
 		s.log.Infof("%s seems to be running already, checking port %d...", serverType, myPort)
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-		up, _, _ := s.testInstance(ctx, myHostAddress, myPort)
+		up, _, _ := s.TestInstance(ctx, myHostAddress, myPort)
 		cancel()
 		if up {
 			s.log.Infof("%s is already running on %d. No need to start anything.", serverType, myPort)
@@ -639,7 +639,7 @@ func (s *Service) runArangod(runner Runner, myPeer Peer, serverType ServerType, 
 				if err != nil {
 					s.log.Fatalf("Cannot collect serverPort: %#v", err)
 				}
-				if up, version, cancelled := s.testInstance(ctx, myHostAddress, port); !cancelled {
+				if up, version, cancelled := s.TestInstance(ctx, myHostAddress, port); !cancelled {
 					if up {
 						s.log.Infof("%s up and running (version %s).", serverType, version)
 						if (serverType == ServerTypeCoordinator && !s.isLocalSlave) || serverType == ServerTypeSingle {

--- a/start.go
+++ b/start.go
@@ -79,8 +79,9 @@ func cmdStartRun(cmd *cobra.Command, args []string) {
 		}
 	})
 
-	log.Infof("Found child args: %#v", childArgs)
+	log.Debugf("Found child args: %#v", childArgs)
 
+	// Start detached child
 	c := exec.Command(exePath, childArgs...)
 	c.Stderr = os.Stderr
 	c.Stdout = os.Stdout

--- a/start.go
+++ b/start.go
@@ -1,0 +1,142 @@
+//
+// DISCLAIMER
+//
+// Copyright 2017 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+// Author Ewout Prangsma
+//
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/arangodb-helper/arangodb/client"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+var (
+	cmdStart = &cobra.Command{
+		Use:   "start",
+		Short: "Start the ArangoDB starter in the background",
+		Run:   cmdStartRun,
+	}
+	waitForServers bool
+)
+
+func init() {
+	f := cmdStart.Flags()
+	f.BoolVar(&waitForServers, "starter.wait", false, "If set, the (parent) starter waits until all database servers are ready before exiting.")
+
+	cmdMain.AddCommand(cmdStart)
+}
+
+func cmdStartRun(cmd *cobra.Command, args []string) {
+	log.Infof("Starting %s version %s, build %s in the background", projectName, projectVersion, projectBuild)
+
+	// Setup logging
+	configureLogging()
+
+	// Build service
+	service := mustPrepareService(false)
+
+	// Find executable
+	exePath, err := os.Executable()
+	if err != nil {
+		log.Fatalf("Cannot find executable path: %#v", err)
+	}
+
+	// Build command line
+	childArgs := make([]string, 0, len(os.Args))
+	cmd.InheritedFlags().VisitAll(func(f *pflag.Flag) {
+		if f.Changed {
+			a := "--" + f.Name
+			value := f.Value.String()
+			if value != "" {
+				a = a + "=" + value
+			}
+			childArgs = append(childArgs, a)
+		}
+	})
+
+	log.Infof("Found child args: %#v", childArgs)
+
+	c := exec.Command(exePath, childArgs...)
+	c.Stderr = os.Stderr
+	c.Stdout = os.Stdout
+	c.Stdin = os.Stdin
+	c.Start()
+
+	// Create starter client
+	scheme := "http"
+	if sslAutoKeyFile || sslKeyFile != "" {
+		scheme = "https"
+	}
+	starterURL, err := url.Parse(fmt.Sprintf("%s://127.0.0.1:%d", scheme, masterPort))
+	if err != nil {
+		log.Fatalf("Failed to create starter URL: %#v", err)
+	}
+	client, err := client.NewArangoStarterClient(*starterURL)
+	if err != nil {
+		log.Fatalf("Failed to create starter client: %#v", err)
+	}
+
+	// Wait for detached starter to be alive
+	rootCtx := context.Background()
+	for {
+		ctx, cancel := context.WithTimeout(rootCtx, time.Second)
+		_, err := client.Version(ctx)
+		cancel()
+		if err == nil {
+			break
+		}
+		time.Sleep(time.Millisecond * 100)
+	}
+
+	// Wait until all servers ready (if needed)
+	if waitForServers {
+		for {
+			var err error
+			ctx, cancel := context.WithTimeout(rootCtx, time.Second)
+			list, err := client.Processes(ctx)
+			cancel()
+			if err == nil && list.ServersStarted {
+				// Start says it has started the servers, now wait for servers to be up.
+				allUp := true
+				for _, server := range list.Servers {
+					ctx, cancel := context.WithTimeout(rootCtx, time.Second)
+					up, _, _ := service.TestInstance(ctx, server.IP, server.Port)
+					cancel()
+					if !up {
+						allUp = false
+						break
+					}
+				}
+				if allUp {
+					break
+				}
+			}
+			time.Sleep(time.Millisecond * 100)
+		}
+	}
+}

--- a/stop.go
+++ b/stop.go
@@ -1,0 +1,84 @@
+//
+// DISCLAIMER
+//
+// Copyright 2017 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+// Author Ewout Prangsma
+//
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/arangodb-helper/arangodb/client"
+	"github.com/spf13/cobra"
+)
+
+var (
+	cmdStop = &cobra.Command{
+		Use:   "stop",
+		Short: "Stop a ArangoDB starter",
+		Run:   cmdStopRun,
+	}
+)
+
+func init() {
+	cmdMain.AddCommand(cmdStop)
+}
+
+func cmdStopRun(cmd *cobra.Command, args []string) {
+	// Setup logging
+	configureLogging()
+
+	// Create starter client
+	scheme := "http"
+	if sslAutoKeyFile || sslKeyFile != "" {
+		scheme = "https"
+	}
+	starterURL, err := url.Parse(fmt.Sprintf("%s://127.0.0.1:%d", scheme, masterPort))
+	if err != nil {
+		log.Fatalf("Failed to create starter URL: %#v", err)
+	}
+	client, err := client.NewArangoStarterClient(*starterURL)
+	if err != nil {
+		log.Fatalf("Failed to create starter client: %#v", err)
+	}
+
+	// Shutdown starter
+	rootCtx := context.Background()
+	ctx, cancel := context.WithTimeout(rootCtx, time.Minute)
+	err = client.Shutdown(ctx, false)
+	cancel()
+	if err != nil {
+		log.Fatalf("Failed to shutdown starter: %#v", err)
+	}
+
+	// Wait for starter to be really gone
+	for {
+		ctx, cancel := context.WithTimeout(rootCtx, time.Second)
+		_, err := client.Version(ctx)
+		cancel()
+		if err != nil {
+			break
+		}
+		time.Sleep(time.Millisecond * 100)
+	}
+}


### PR DESCRIPTION
This PR adds 2 commands to the starter:

- `arangodb start ...` Start the starter as detached process.
- `arangodb stop` Stop a running starter through its API