### PR TITLE
Adding option to improve cluster testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changes from version 0.8.0 to master 
 
+- Added `--starter.debug-cluster` option that adds a trail of status codes to the log when starting servers. (intended mostly for internal testing)
 - Made database image used in test configurable using `ARANGODB` make variable.
 - Added `--docker.tty` option for controlling the TTY flag of started docker containers.
 - In cluster mode the minimum agency size has been lowered to 1 (DO NOT USE IN PRODUCTION). 

--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,7 @@ run-tests-local-process: build test-images
 		-e DATA_DIR=/tmp \
 		-e STARTER=/usr/code/bin/linux/amd64/arangodb \
 		-e TEST_MODES=localprocess \
+		-e DEBUG_CLUSTER=$(DEBUG_CLUSTER) \
 		-w /usr/code/ \
 		arangodb-golang \
 		go test -v $(REPOPATH)/test

--- a/README.md
+++ b/README.md
@@ -394,6 +394,11 @@ If `docker.tty` is set, all docker containers will be started with a TTY.
 If the starter itself is running in a docker container without a TTY 
 this option is overwritten to `false`.
 
+* `--starter.debug-cluster=bool`
+
+IF `starter.debug-cluster` is set, the start will record the status codes it receives
+upon "server ready" requests to the log. This option is mainly intended for internal testing.
+
 HTTP API
 --------
 

--- a/main.go
+++ b/main.go
@@ -96,6 +96,7 @@ var (
 	dockerPrivileged         bool
 	dockerTTY                bool
 	passthroughOptions       = make(map[string]*service.PassthroughOption)
+	debugCluster             bool
 
 	maskAny = errors.WithStack
 )
@@ -111,6 +112,7 @@ func init() {
 	f.IntVar(&masterPort, "starter.port", service.DefaultMasterPort, "Port to listen on for other arangodb's to join")
 	f.BoolVar(&allPortOffsetsUnique, "starter.unique-port-offsets", false, "If set, all peers will get a unique port offset. If false (default) only portOffset+peerAddress pairs will be unique.")
 	f.StringVar(&dataDir, "starter.data-dir", getEnvVar("DATA_DIR", "."), "directory to store all data the starter generates (and holds actual database directories)")
+	f.BoolVar(&debugCluster, "starter.debug-cluster", getEnvVar("DEBUG_CLUSTER", "") != "", "If set, log more information to debug a cluster")
 
 	f.BoolVar(&verbose, "log.verbose", false, "Turn on debug logging")
 
@@ -480,6 +482,7 @@ func mustPrepareService(generateAutoKeyFile bool) *service.Service {
 		DockerTTY:                dockerTTY,
 		ProjectVersion:           projectVersion,
 		ProjectBuild:             projectBuild,
+		DebugCluster:             debugCluster,
 	}
 	for _, ptOpt := range passthroughOptions {
 		serviceConfig.PassthroughOptions = append(serviceConfig.PassthroughOptions, *ptOpt)

--- a/start.go
+++ b/start.go
@@ -136,7 +136,7 @@ func cmdStartRun(cmd *cobra.Command, args []string) {
 				allUp := true
 				for _, server := range list.Servers {
 					ctx, cancel := context.WithTimeout(rootCtx, time.Second)
-					up, _, _ := service.TestInstance(ctx, server.IP, server.Port)
+					up, _, _, _ := service.TestInstance(ctx, server.IP, server.Port, nil)
 					cancel()
 					if !up {
 						allUp = false

--- a/test/docker_cluster_default_test.go
+++ b/test/docker_cluster_default_test.go
@@ -75,7 +75,7 @@ func TestDockerClusterDefault(t *testing.T) {
 		"arangodb/arangodb-starter",
 		"--docker.container=" + cID1,
 		"--starter.address=$IP",
-		createDockerImageOptions(),
+		createEnvironmentStarterOptions(),
 	}, " "))
 	defer dockerRun1.Close()
 	defer removeDockerContainer(t, cID1)
@@ -92,7 +92,7 @@ func TestDockerClusterDefault(t *testing.T) {
 		"arangodb/arangodb-starter",
 		"--docker.container=" + cID2,
 		"--starter.address=$IP",
-		createDockerImageOptions(),
+		createEnvironmentStarterOptions(),
 		fmt.Sprintf("--starter.join=$IP:%d", basePort),
 	}, " "))
 	defer dockerRun2.Close()
@@ -110,7 +110,7 @@ func TestDockerClusterDefault(t *testing.T) {
 		"arangodb/arangodb-starter",
 		"--docker.container=" + cID3,
 		"--starter.address=$IP",
-		createDockerImageOptions(),
+		createEnvironmentStarterOptions(),
 		fmt.Sprintf("--starter.join=$IP:%d", basePort),
 	}, " "))
 	defer dockerRun3.Close()
@@ -176,7 +176,7 @@ func TestOldDockerClusterDefault(t *testing.T) {
 		"arangodb/arangodb-starter",
 		"--dockerContainer=" + cID1,
 		"--ownAddress=$IP",
-		createDockerImageOptions(),
+		createEnvironmentStarterOptions(),
 	}, " "))
 	defer dockerRun1.Close()
 	defer removeDockerContainer(t, cID1)
@@ -193,7 +193,7 @@ func TestOldDockerClusterDefault(t *testing.T) {
 		"arangodb/arangodb-starter",
 		"--dockerContainer=" + cID2,
 		"--ownAddress=$IP",
-		createDockerImageOptions(),
+		createEnvironmentStarterOptions(),
 		fmt.Sprintf("--join=$IP:%d", basePort),
 	}, " "))
 	defer dockerRun2.Close()
@@ -211,7 +211,7 @@ func TestOldDockerClusterDefault(t *testing.T) {
 		"arangodb/arangodb-starter",
 		"--dockerContainer=" + cID3,
 		"--ownAddress=$IP",
-		createDockerImageOptions(),
+		createEnvironmentStarterOptions(),
 		fmt.Sprintf("--join=$IP:%d", basePort),
 	}, " "))
 	defer dockerRun3.Close()

--- a/test/docker_cluster_local_test.go
+++ b/test/docker_cluster_local_test.go
@@ -69,7 +69,7 @@ func TestDockerClusterLocal(t *testing.T) {
 		"--docker.container=" + cID,
 		"--starter.address=$IP",
 		"--starter.local",
-		createDockerImageOptions(),
+		createEnvironmentStarterOptions(),
 	}, " "))
 	defer dockerRun.Close()
 	defer removeDockerContainer(t, cID)
@@ -123,7 +123,7 @@ func TestOldDockerClusterLocal(t *testing.T) {
 		"--dockerContainer=" + cID,
 		"--ownAddress=$IP",
 		"--local",
-		createDockerImageOptions(),
+		createEnvironmentStarterOptions(),
 	}, " "))
 	defer dockerRun.Close()
 	defer removeDockerContainer(t, cID)

--- a/test/docker_single_test.go
+++ b/test/docker_single_test.go
@@ -69,7 +69,7 @@ func TestDockerSingle(t *testing.T) {
 		"--docker.container=" + cID,
 		"--starter.address=$IP",
 		"--starter.mode=single",
-		createDockerImageOptions(),
+		createEnvironmentStarterOptions(),
 	}, " "))
 	defer dockerRun.Close()
 	defer removeDockerContainer(t, cID)
@@ -126,7 +126,7 @@ func TestDockerSingleAutoKeyFile(t *testing.T) {
 		"--starter.address=$IP",
 		"--starter.mode=single",
 		"--ssl.auto-key",
-		createDockerImageOptions(),
+		createEnvironmentStarterOptions(),
 	}, " "))
 	defer dockerRun.Close()
 	defer removeDockerContainer(t, cID)
@@ -179,7 +179,7 @@ func TestDockerSingleAutoContainerName(t *testing.T) {
 		"arangodb/arangodb-starter",
 		"--starter.address=$IP",
 		"--starter.mode=single",
-		createDockerImageOptions(),
+		createEnvironmentStarterOptions(),
 	}, " "))
 	defer dockerRun.Close()
 	defer removeDockerContainer(t, cID)
@@ -236,7 +236,7 @@ func TestDockerSingleAutoRocksdb(t *testing.T) {
 		"--starter.mode=single",
 		"--server.storage-engine=rocksdb",
 		"--docker.image=arangodb/arangodb-preview:3.2.devel",
-		createDockerImageOptions(),
+		createEnvironmentStarterOptions(),
 	}, " "))
 	defer dockerRun.Close()
 	defer removeDockerContainer(t, cID)
@@ -291,7 +291,7 @@ func TestOldDockerSingleAutoKeyFile(t *testing.T) {
 		"--ownAddress=$IP",
 		"--mode=single",
 		"--sslAutoKeyFile",
-		createDockerImageOptions(),
+		createEnvironmentStarterOptions(),
 	}, " "))
 	defer dockerRun.Close()
 	defer removeDockerContainer(t, cID)

--- a/test/docker_util.go
+++ b/test/docker_util.go
@@ -26,7 +26,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
-	"os"
 	"os/exec"
 	"strings"
 	"testing"
@@ -80,12 +79,4 @@ func createDockerID(prefix string) string {
 		panic(err)
 	}
 	return prefix + hex.EncodeToString(b)
-}
-
-func createDockerImageOptions() string {
-	if image := os.Getenv("ARANGODB"); image == "" {
-		return ""
-	} else {
-		return fmt.Sprintf("--docker.image=%s", image)
-	}
 }

--- a/test/process_cluster_default_test.go
+++ b/test/process_cluster_default_test.go
@@ -36,17 +36,17 @@ func TestProcessClusterDefault(t *testing.T) {
 
 	start := time.Now()
 
-	master := Spawn(t, "${STARTER}")
+	master := Spawn(t, "${STARTER} "+createEnvironmentStarterOptions())
 	defer master.Close()
 
 	dataDirSlave1 := SetUniqueDataDir(t)
 	defer os.RemoveAll(dataDirSlave1)
-	slave1 := Spawn(t, "${STARTER} --starter.join 127.0.0.1")
+	slave1 := Spawn(t, "${STARTER} --starter.join 127.0.0.1 "+createEnvironmentStarterOptions())
 	defer slave1.Close()
 
 	dataDirSlave2 := SetUniqueDataDir(t)
 	defer os.RemoveAll(dataDirSlave2)
-	slave2 := Spawn(t, "${STARTER} --starter.join 127.0.0.1")
+	slave2 := Spawn(t, "${STARTER} --starter.join 127.0.0.1 "+createEnvironmentStarterOptions())
 	defer slave2.Close()
 
 	if ok := WaitUntilStarterReady(t, whatCluster, master, slave1, slave2); ok {
@@ -70,17 +70,17 @@ func TestProcessClusterDefaultShutdownViaAPI(t *testing.T) {
 
 	start := time.Now()
 
-	master := Spawn(t, "${STARTER}")
+	master := Spawn(t, "${STARTER} "+createEnvironmentStarterOptions())
 	defer master.Close()
 
 	dataDirSlave1 := SetUniqueDataDir(t)
 	defer os.RemoveAll(dataDirSlave1)
-	slave1 := Spawn(t, "${STARTER} --starter.join 127.0.0.1")
+	slave1 := Spawn(t, "${STARTER} --starter.join 127.0.0.1 "+createEnvironmentStarterOptions())
 	defer slave1.Close()
 
 	dataDirSlave2 := SetUniqueDataDir(t)
 	defer os.RemoveAll(dataDirSlave2)
-	slave2 := Spawn(t, "${STARTER} --starter.join 127.0.0.1")
+	slave2 := Spawn(t, "${STARTER} --starter.join 127.0.0.1 "+createEnvironmentStarterOptions())
 	defer slave2.Close()
 
 	if ok := WaitUntilStarterReady(t, whatCluster, master, slave1, slave2); ok {
@@ -106,17 +106,17 @@ func TestOldProcessClusterDefault(t *testing.T) {
 
 	start := time.Now()
 
-	master := Spawn(t, "${STARTER}")
+	master := Spawn(t, "${STARTER} "+createEnvironmentStarterOptions())
 	defer master.Close()
 
 	dataDirSlave1 := SetUniqueDataDir(t)
 	defer os.RemoveAll(dataDirSlave1)
-	slave1 := Spawn(t, "${STARTER} --join 127.0.0.1")
+	slave1 := Spawn(t, "${STARTER} --join 127.0.0.1 "+createEnvironmentStarterOptions())
 	defer slave1.Close()
 
 	dataDirSlave2 := SetUniqueDataDir(t)
 	defer os.RemoveAll(dataDirSlave2)
-	slave2 := Spawn(t, "${STARTER} --join 127.0.0.1")
+	slave2 := Spawn(t, "${STARTER} --join 127.0.0.1 "+createEnvironmentStarterOptions())
 	defer slave2.Close()
 
 	if ok := WaitUntilStarterReady(t, whatCluster, master, slave1, slave2); ok {

--- a/test/process_cluster_local_test.go
+++ b/test/process_cluster_local_test.go
@@ -36,7 +36,7 @@ func TestProcessClusterLocal(t *testing.T) {
 
 	start := time.Now()
 
-	child := Spawn(t, "${STARTER} --starter.local")
+	child := Spawn(t, "${STARTER} --starter.local "+createEnvironmentStarterOptions())
 	defer child.Close()
 
 	if ok := WaitUntilStarterReady(t, whatCluster, child); ok {
@@ -60,7 +60,7 @@ func TestProcessClusterLocalShutdownViaAPI(t *testing.T) {
 
 	start := time.Now()
 
-	child := Spawn(t, "${STARTER} --starter.local")
+	child := Spawn(t, "${STARTER} --starter.local "+createEnvironmentStarterOptions())
 	defer child.Close()
 
 	if ok := WaitUntilStarterReady(t, whatCluster, child); ok {
@@ -84,7 +84,7 @@ func TestOldProcessClusterLocal(t *testing.T) {
 
 	start := time.Now()
 
-	child := Spawn(t, "${STARTER} --local")
+	child := Spawn(t, "${STARTER} --local "+createEnvironmentStarterOptions())
 	defer child.Close()
 
 	if ok := WaitUntilStarterReady(t, whatCluster, child); ok {

--- a/test/process_single_test.go
+++ b/test/process_single_test.go
@@ -36,7 +36,7 @@ func TestProcessSingle(t *testing.T) {
 
 	start := time.Now()
 
-	child := Spawn(t, "${STARTER} --starter.mode=single")
+	child := Spawn(t, "${STARTER} --starter.mode=single "+createEnvironmentStarterOptions())
 	defer child.Close()
 
 	if ok := WaitUntilStarterReady(t, whatSingle, child); ok {
@@ -58,7 +58,7 @@ func TestProcessSingleShutdownViaAPI(t *testing.T) {
 
 	start := time.Now()
 
-	child := Spawn(t, "${STARTER} --starter.mode=single")
+	child := Spawn(t, "${STARTER} --starter.mode=single "+createEnvironmentStarterOptions())
 	defer child.Close()
 
 	if ok := WaitUntilStarterReady(t, whatSingle, child); ok {
@@ -80,7 +80,7 @@ func TestProcessSingleAutoKeyFile(t *testing.T) {
 
 	start := time.Now()
 
-	child := Spawn(t, "${STARTER} --starter.mode=single --ssl.auto-key")
+	child := Spawn(t, "${STARTER} --starter.mode=single --ssl.auto-key "+createEnvironmentStarterOptions())
 	defer child.Close()
 
 	if ok := WaitUntilStarterReady(t, whatSingle, child); ok {
@@ -102,7 +102,7 @@ func TestOldProcessSingle(t *testing.T) {
 
 	start := time.Now()
 
-	child := Spawn(t, "${STARTER} --mode=single")
+	child := Spawn(t, "${STARTER} --mode=single "+createEnvironmentStarterOptions())
 	defer child.Close()
 
 	if ok := WaitUntilStarterReady(t, whatSingle, child); ok {
@@ -124,7 +124,7 @@ func TestOldProcessSingleAutoKeyFile(t *testing.T) {
 
 	start := time.Now()
 
-	child := Spawn(t, "${STARTER} --mode=single --sslAutoKeyFile")
+	child := Spawn(t, "${STARTER} --mode=single --sslAutoKeyFile "+createEnvironmentStarterOptions())
 	defer child.Close()
 
 	if ok := WaitUntilStarterReady(t, whatSingle, child); ok {


### PR DESCRIPTION
Adding option `--starter.debug-cluster` which will add a status code trail to the logs for each server that is starting.