### PR TITLE
Include travis tests for arangodb 3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ services:
 language: go
 
 env:
+  - TEST_SUITE=run-tests-local-process ARANGODB=arangodb:3.1
+  - TEST_SUITE=run-tests-docker        ARANGODB=arangodb:3.1
   - TEST_SUITE=run-tests-local-process ARANGODB=arangodb/arangodb:latest
   - TEST_SUITE=run-tests-docker        ARANGODB=arangodb/arangodb:latest
   - TEST_SUITE=run-tests-local-process ARANGODB=arangodb/arangodb-preview:latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,12 @@ env:
 
 script: make $TEST_SUITE
 
+# 3.1 cluster startup is not always a success, causing lots of false positive.
+matrix:
+  allow_failures:
+    - env: TEST_SUITE=run-tests-local-process ARANGODB=arangodb:3.1
+    - env: TEST_SUITE=run-tests-docker        ARANGODB=arangodb:3.1
+
 # Install Docker CE
 before_install:
   - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -


### PR DESCRIPTION
Add explicit tests for 3.1 now that `latest` is 3.2