### PR TITLE
Avoid adding offset to port when not needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Changes from version 0.8.1 to master 
+
+- Avoid using port offsets when using different `--starter.port`s that cause no overlap of port ranges.
+- Cluster configuration is updated to all starters at regular intervals after 
+  the starters have bootstrapped and reached a running state.
+- After starters have bootstrapped, they elect a starter to be master over the cluster configuration.
+  All changes (addition/removal) are forwarded to this master. 
+  When the master is gone for too long, a new master is elected.
 # Changes from version 0.8.0 to master 
 
 - Fixed cluster setup in case where starters use different `--starter.port`s (#68).

--- a/service/cluster_config.go
+++ b/service/cluster_config.go
@@ -122,12 +122,12 @@ func (p ClusterConfig) IDs() []string {
 }
 
 // GetFreePortOffset returns the first unallocated port offset.
-func (p ClusterConfig) GetFreePortOffset(peerAddress string, allPortOffsetsUnique bool) int {
+func (p ClusterConfig) GetFreePortOffset(peerAddress string, basePort int, allPortOffsetsUnique bool) int {
 	portOffset := 0
 	for {
 		found := false
 		for _, p := range p.AllPeers {
-			if p.PortOffset == portOffset {
+			if p.PortRangeOverlaps(basePort + portOffset) {
 				if allPortOffsetsUnique || p.Address == peerAddress {
 					found = true
 					break

--- a/service/peer.go
+++ b/service/peer.go
@@ -120,3 +120,14 @@ func (p Peer) CreateCoordinatorAPI(prepareRequest func(*http.Request) error) (ar
 		return nil, maskAny(fmt.Errorf("Peer has no coordinator"))
 	}
 }
+
+// PortRangeOverlaps returns true if the port range of this peer overlaps with a port
+// range starting at given port.
+func (p Peer) PortRangeOverlaps(otherPort int) bool {
+	myStart := p.Port + p.PortOffset                // Inclusive
+	myEnd := myStart + portOffsetIncrement - 1      // Inclusive
+	otherEnd := otherPort + portOffsetIncrement - 1 // Inclusive
+
+	return (otherPort >= myStart && otherPort <= myEnd) ||
+		(otherEnd >= myStart && otherEnd <= myEnd)
+}

--- a/service/service.go
+++ b/service/service.go
@@ -408,7 +408,7 @@ func (s *Service) serverPort(serverType ServerType) (int, error) {
 	}
 	// Find log path
 	portOffset := myPeer.PortOffset
-	return s.cfg.MasterPort + portOffset + serverType.PortOffset(), nil
+	return myPeer.Port + portOffset + serverType.PortOffset(), nil
 }
 
 // serverHostDir returns the path of the folder (in host namespace) containing data for the given server.
@@ -640,6 +640,7 @@ func (s *Service) HandleHello(ownAddress, remoteAddress string, req *HelloReques
 			}
 			// ID not yet found, add it
 			portOffset := s.myPeers.GetFreePortOffset(slaveAddr, slavePort, s.cfg.AllPortOffsetsUnique)
+			s.log.Debugf("Set slave port offset to %d, got slaveAddr=%s, slavePort=%d", portOffset, slaveAddr, slavePort)
 			hasAgent := s.mode.IsClusterMode() && !s.myPeers.HaveEnoughAgents()
 			if req.Agent != nil {
 				hasAgent = *req.Agent
@@ -714,7 +715,7 @@ func (s *Service) MasterChangedCallback() {
 func (s *Service) getHTTPServerPort() (containerPort, hostPort int, err error) {
 	containerPort = s.cfg.MasterPort
 	hostPort = s.announcePort
-	//s.log.Debug("hostPort=%d masterPort=%d #AllPeers=%d", hostPort, s.cfg.MasterPort, len(s.myPeers.AllPeers))
+	s.log.Debugf("hostPort=%d masterPort=%d #AllPeers=%d", hostPort, s.cfg.MasterPort, len(s.myPeers.AllPeers))
 	if s.announcePort == s.cfg.MasterPort && len(s.myPeers.AllPeers) > 0 {
 		if myPeer, ok := s.myPeers.PeerByID(s.id); ok {
 			containerPort += myPeer.PortOffset

--- a/service/service.go
+++ b/service/service.go
@@ -639,7 +639,7 @@ func (s *Service) HandleHello(ownAddress, remoteAddress string, req *HelloReques
 				return ClusterConfig{}, maskAny(errors.Wrap(client.BadRequestError, "In single server mode, slaves cannot be added."))
 			}
 			// ID not yet found, add it
-			portOffset := s.myPeers.GetFreePortOffset(slaveAddr, s.cfg.AllPortOffsetsUnique)
+			portOffset := s.myPeers.GetFreePortOffset(slaveAddr, slavePort, s.cfg.AllPortOffsetsUnique)
 			hasAgent := s.mode.IsClusterMode() && !s.myPeers.HaveEnoughAgents()
 			if req.Agent != nil {
 				hasAgent = *req.Agent

--- a/test/docker_cluster_default_test.go
+++ b/test/docker_cluster_default_test.go
@@ -190,7 +190,6 @@ func TestDockerClusterDifferentPorts(t *testing.T) {
 		"--name=" + cID2,
 		"--rm",
 		"-p 7000:7000",
-		"-p 7005:7005",
 		fmt.Sprintf("-v %s:/data", volID2),
 		"-v /var/run/docker.sock:/var/run/docker.sock",
 		"arangodb/arangodb-starter",
@@ -210,7 +209,6 @@ func TestDockerClusterDifferentPorts(t *testing.T) {
 		"--name=" + cID3,
 		"--rm",
 		"-p 8000:8000",
-		"-p 8010:8010",
 		fmt.Sprintf("-v %s:/data", volID3),
 		"-v /var/run/docker.sock:/var/run/docker.sock",
 		"arangodb/arangodb-starter",
@@ -226,16 +224,16 @@ func TestDockerClusterDifferentPorts(t *testing.T) {
 	if ok := WaitUntilStarterReady(t, whatCluster, dockerRun1, dockerRun2, dockerRun3); ok {
 		t.Logf("Cluster start took %s", time.Since(start))
 		testCluster(t, "http://localhost:6000", false)
-		testCluster(t, "http://localhost:7005", false)
-		testCluster(t, "http://localhost:8010", false)
+		testCluster(t, "http://localhost:7000", false)
+		testCluster(t, "http://localhost:8000", false)
 	}
 
 	if isVerbose {
 		t.Log("Waiting for termination")
 	}
 	ShutdownStarter(t, "http://localhost:6000")
-	ShutdownStarter(t, "http://localhost:7005")
-	ShutdownStarter(t, "http://localhost:8010")
+	ShutdownStarter(t, "http://localhost:7000")
+	ShutdownStarter(t, "http://localhost:8000")
 }
 
 // TestOldDockerClusterDefault runs 3 arangodb starters in docker with default settings.

--- a/test/process_cluster_default_test.go
+++ b/test/process_cluster_default_test.go
@@ -124,8 +124,8 @@ func TestProcessClusterDifferentPorts(t *testing.T) {
 	if ok := WaitUntilStarterReady(t, whatCluster, master, slave1, slave2); ok {
 		t.Logf("Cluster start took %s", time.Since(start))
 		testCluster(t, "http://localhost:6000", false)
-		testCluster(t, "http://localhost:7005", false)
-		testCluster(t, "http://localhost:8010", false)
+		testCluster(t, "http://localhost:7000", false)
+		testCluster(t, "http://localhost:8000", false)
 	}
 
 	if isVerbose {


### PR DESCRIPTION
When multiple starters use the same address, but a different `--starter.port` there is no need to use port offsets. It is confusing and make (especially) the docker use case more complicated because not only the configured port needs a port mapping, but also the configured port + port offset needs a port mapping.