### PR TITLE
Avoid registering for a callback notification when I don't want to be master any

### DIFF
--- a/service/runtime_cluster_manager.go
+++ b/service/runtime_cluster_manager.go
@@ -272,7 +272,7 @@ func (s *runtimeClusterManager) Run(ctx context.Context, log *logging.Logger, ru
 			s.mutex.Unlock()
 
 			// Register master changed callback (if needed)
-			if !callbackRegistered && masterURL != "" {
+			if !callbackRegistered && masterURL != "" && !s.avoidBeingMaster {
 				log.Debug("Register master callback...")
 				if err := s.registerMasterChangedCallback(ctx, ownURL); err != nil {
 					log.Debugf("Failed to register master callback: %#v", err)

--- a/test/Dockerfile-arangodb-golang
+++ b/test/Dockerfile-arangodb-golang
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		pkg-config \
         wget \
 		ca-certificates \
+		procps \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV GOLANG_VERSION 1.8.3


### PR DESCRIPTION
This problem causes warnings in the agency when it cannot perform a callback to a local slave becuase it has no docker port mapping.