### PR TITLE
Support disabling IPv6 notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Changes from version 0.9.1 to 0.9.2
+
+- Added `--starter.disable-ipv6` option to cope with environments 
+  where IPv6 is actively disabled.
+
 # Changes from version 0.9.0 to 0.9.1 
 
 - Update to go 1.9.0

--- a/README.md
+++ b/README.md
@@ -383,6 +383,14 @@ the other servers are derived from this number.
 This is the port used for communication of the `arangodb` instances
 amongst each other.
 
+* `--starter.disable-ipv6=bool` 
+
+if disabled, the starter will configure the `arangod` servers 
+to bind to address `0.0.0.0` (all IPv4 interfaces) 
+instead of binding to `[::]` (all IPv4 and all IPv6 interfaces).
+
+This is useful when IPv6 has actively been disabled on your machine.
+
 * `--server.arangod=path`
 
 path to the `arangod` executable (default varies from platform to

--- a/main.go
+++ b/main.go
@@ -86,6 +86,7 @@ var (
 	sslAutoOrganization      string
 	sslCAFile                string
 	rocksDBEncryptionKeyFile string
+	disableIPv6              bool
 	dockerEndpoint           string
 	dockerImage              string
 	dockerImagePullPolicy    string
@@ -115,6 +116,7 @@ func init() {
 	f.BoolVar(&allPortOffsetsUnique, "starter.unique-port-offsets", false, "If set, all peers will get a unique port offset. If false (default) only portOffset+peerAddress pairs will be unique.")
 	f.StringVar(&dataDir, "starter.data-dir", getEnvVar("DATA_DIR", "."), "directory to store all data the starter generates (and holds actual database directories)")
 	f.BoolVar(&debugCluster, "starter.debug-cluster", getEnvVar("DEBUG_CLUSTER", "") != "", "If set, log more information to debug a cluster")
+	f.BoolVar(&disableIPv6, "starter.disable-ipv6", false, "If set, no IPv6 notation will be used. Use this only when IPv6 address family is disabled")
 
 	f.BoolVar(&verbose, "log.verbose", false, "Turn on debug logging")
 
@@ -487,6 +489,7 @@ func mustPrepareService(generateAutoKeyFile bool) (*service.Service, service.Boo
 		SslKeyFile:               sslKeyFile,
 		SslCAFile:                sslCAFile,
 		RocksDBEncryptionKeyFile: rocksDBEncryptionKeyFile,
+		DisableIPv6:              disableIPv6,
 	}
 	bsCfg.Initialize()
 	serviceConfig := service.Config{

--- a/main.go
+++ b/main.go
@@ -35,13 +35,15 @@ import (
 	"syscall"
 	"time"
 
-	_ "github.com/arangodb-helper/arangodb/client"
-	service "github.com/arangodb-helper/arangodb/service"
 	homedir "github.com/mitchellh/go-homedir"
 	logging "github.com/op/go-logging"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+
+	_ "github.com/arangodb-helper/arangodb/client"
+	"github.com/arangodb-helper/arangodb/pkg/net"
+	service "github.com/arangodb-helper/arangodb/service"
 )
 
 // Configuration data with defaults:
@@ -116,7 +118,7 @@ func init() {
 	f.BoolVar(&allPortOffsetsUnique, "starter.unique-port-offsets", false, "If set, all peers will get a unique port offset. If false (default) only portOffset+peerAddress pairs will be unique.")
 	f.StringVar(&dataDir, "starter.data-dir", getEnvVar("DATA_DIR", "."), "directory to store all data the starter generates (and holds actual database directories)")
 	f.BoolVar(&debugCluster, "starter.debug-cluster", getEnvVar("DEBUG_CLUSTER", "") != "", "If set, log more information to debug a cluster")
-	f.BoolVar(&disableIPv6, "starter.disable-ipv6", false, "If set, no IPv6 notation will be used. Use this only when IPv6 address family is disabled")
+	f.BoolVar(&disableIPv6, "starter.disable-ipv6", !net.IsIPv6Supported(), "If set, no IPv6 notation will be used. Use this only when IPv6 address family is disabled")
 
 	f.BoolVar(&verbose, "log.verbose", false, "Turn on debug logging")
 

--- a/pkg/net/ipv6.go
+++ b/pkg/net/ipv6.go
@@ -1,0 +1,33 @@
+//
+// DISCLAIMER
+//
+// Copyright 2017 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+// Author Ewout Prangsma
+//
+
+// +build !linux
+
+package net
+
+// IsIPv6Supported returns true when IPv6 support is available,
+// false when it is not.
+// Note that it is not possible on all platforms to properly
+// detect IPv6 support.
+func IsIPv6Supported() bool {
+	return true
+}

--- a/pkg/net/ipv6_linux.go
+++ b/pkg/net/ipv6_linux.go
@@ -1,0 +1,36 @@
+//
+// DISCLAIMER
+//
+// Copyright 2017 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+// Author Ewout Prangsma
+//
+
+package net
+
+import "os"
+
+// IsIPv6Supported returns true when IPv6 support is available,
+// false when it is not.
+// Note that it is not possible on all platforms to properly
+// detect IPv6 support.
+func IsIPv6Supported() bool {
+	if _, err := os.Stat("/proc/net/if_inet6"); err == nil {
+		return true
+	}
+	return false
+}

--- a/service/arangod_config_builder.go
+++ b/service/arangod_config_builder.go
@@ -84,11 +84,15 @@ func createArangodConf(log *logging.Logger, bsCfg BootstrapConfig, myHostDir, my
 		threads = "16"
 		v8Contexts = "4"
 	}
+	listenAddr := "[::]"
+	if bsCfg.DisableIPv6 {
+		listenAddr = "0.0.0.0"
+	}
 	scheme := NewURLSchemes(bsCfg.SslKeyFile != "").Arangod
 	serverSection := &configSection{
 		Name: "server",
 		Settings: map[string]string{
-			"endpoint":       fmt.Sprintf("%s://[::]:%s", scheme, myPort),
+			"endpoint":       fmt.Sprintf("%s://%s:%s", scheme, listenAddr, myPort),
 			"threads":        threads,
 			"authentication": "false",
 		},

--- a/service/bootstrap_config.go
+++ b/service/bootstrap_config.go
@@ -39,6 +39,7 @@ type BootstrapConfig struct {
 	SslKeyFile               string      // Path containing an x509 certificate + private key to be used by the servers.
 	SslCAFile                string      // Path containing an x509 CA certificate used to authenticate clients.
 	RocksDBEncryptionKeyFile string      // Path containing encryption key for RocksDB encryption.
+	DisableIPv6              bool        // If set, no IPv6 notation will be used
 }
 
 // Initialize auto-configures some optional values


### PR DESCRIPTION
Added `--starter.disable-ipv6` option to force binding to `0.0.0.0` instead of `[::]`.