### PR TITLE
Support building without docker in a different directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Changes from version 0.10.2 to master
+
+- Support building in a directory other than the source directory. Set `BUILDDIR` (#98).
+
 # Changes from version 0.10.1 to 0.10.2
 
 - Starting with mode `resilientsingle` and `--starter.local` will no longer limit

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ VERSION_MAJOR_MINOR_PATCH := $(shell echo $(VERSION) | cut -f 1 -d '+')
 VERSION_MAJOR_MINOR := $(shell echo $(VERSION_MAJOR_MINOR_PATCH) | cut -f 1,2 -d '.')
 VERSION_MAJOR := $(shell echo $(VERSION_MAJOR_MINOR) | cut -f 1 -d '.')
 COMMIT := $(shell git rev-parse --short HEAD)
+MAKEFILE := $(ROOTDIR)/Makefile
 
 ifndef NODOCKER
 	DOCKERCLI := $(shell which docker)
@@ -74,9 +75,9 @@ clean:
 
 local:
 ifneq ("$(DOCKERCLI)", "")
-	@${MAKE} -B GOOS=$(shell go env GOHOSTOS) GOARCH=$(shell go env GOHOSTARCH) build-local
+	@${MAKE} -f $(MAKEFILE) -B GOOS=$(shell go env GOHOSTOS) GOARCH=$(shell go env GOHOSTARCH) build-local
 else
-	@${MAKE} deps
+	@${MAKE} -f $(MAKEFILE) deps
 	GOPATH=$(GOBUILDDIR) go build -o $(BUILDDIR)/arangodb $(REPOPATH)
 endif
 
@@ -86,12 +87,12 @@ build-local: build
 	@ln -sf $(BIN) $(ROOTDIR)/arangodb
 
 binaries: $(GHRELEASE)
-	@${MAKE} -B GOOS=linux GOARCH=amd64 build
-	@${MAKE} -B GOOS=darwin GOARCH=amd64 build
-	@${MAKE} -B GOOS=windows GOARCH=amd64 build
+	@${MAKE} -f $(MAKEFILE) -B GOOS=linux GOARCH=amd64 build
+	@${MAKE} -f $(MAKEFILE) -B GOOS=darwin GOARCH=amd64 build
+	@${MAKE} -f $(MAKEFILE) -B GOOS=windows GOARCH=amd64 build
 
 deps:
-	@${MAKE} -B SCRIPTDIR=$(SCRIPTDIR) BUILDDIR=$(BUILDDIR) -s $(GOBUILDDIR)
+	@${MAKE} -f $(MAKEFILE) -B SCRIPTDIR=$(SCRIPTDIR) BUILDDIR=$(BUILDDIR) -s $(GOBUILDDIR)
 
 $(GOBUILDDIR):
 	@mkdir -p $(ORGDIR)


### PR DESCRIPTION
fixes #98 

To use, run:

```
make NODOCKER=1 BUILDDIR=/tmp/someDir SCRIPTDIR=dirContainingSources  local
```