### PR TITLE
Check role on instance (next to up check)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changes from version 0.10.2 to master
 
 - Support building in a directory other than the source directory. Set `BUILDDIR` (#98).
+- Testing a server instance now includes testing for the expected server role.
 
 # Changes from version 0.10.1 to 0.10.2
 

--- a/service/runtime_server_manager.go
+++ b/service/runtime_server_manager.go
@@ -59,7 +59,8 @@ type runtimeServerManagerContext interface {
 	serverHostDir(serverType ServerType) (string, error)
 
 	// TestInstance checks the `up` status of an arangod server instance.
-	TestInstance(ctx context.Context, address string, port int, statusChanged chan StatusItem) (up bool, version string, statusTrail []int, cancelled bool)
+	TestInstance(ctx context.Context, address string, port int, expectedRole, expectedMode string,
+		statusChanged chan StatusItem) (up, correctRole bool, version, role, mode string, statusTrail []int, cancelled bool)
 
 	// IsLocalSlave returns true if this peer is running as a local slave
 	IsLocalSlave() bool
@@ -91,13 +92,17 @@ func startArangod(log *logging.Logger, runtimeContext runtimeServerManagerContex
 	if p != nil {
 		log.Infof("%s seems to be running already, checking port %d...", serverType, myPort)
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-		up, _, _, _ := runtimeContext.TestInstance(ctx, myHostAddress, myPort, nil)
+		expectedRole, expectedMode := serverType.ExpectedServerRole()
+		up, correctRole, _, _, _, _, _ := runtimeContext.TestInstance(ctx, myHostAddress, myPort, expectedRole, expectedMode, nil)
 		cancel()
-		if up {
+		if up && correctRole {
 			log.Infof("%s is already running on %d. No need to start anything.", serverType, myPort)
 			return p, false, nil
+		} else if !up {
+			log.Infof("%s is not up on port %d. Terminating existing process and restarting it...", serverType, myPort)
+		} else if !correctRole {
+			log.Infof("%s is not of role '%s' on port %d. Terminating existing process and restarting it...", serverType, expectedRole, myPort)
 		}
-		log.Infof("%s is not up on port %d. Terminating existing process and restarting it...", serverType, myPort)
 		p.Terminate()
 	}
 
@@ -219,8 +224,9 @@ func (s *runtimeServerManager) runArangod(ctx context.Context, log *logging.Logg
 						}
 					}
 				}()
-				if up, version, statusTrail, cancelled := runtimeContext.TestInstance(ctx, myHostAddress, port, statusChanged); !cancelled {
-					if up {
+				expectedRole, expectedMode := serverType.ExpectedServerRole()
+				if up, correctRole, version, role, mode, statusTrail, cancelled := runtimeContext.TestInstance(ctx, myHostAddress, port, expectedRole, expectedMode, statusChanged); !cancelled {
+					if up && correctRole {
 						log.Infof("%s up and running (version %s).", serverType, version)
 						if (serverType == ServerTypeCoordinator && !runtimeContext.IsLocalSlave()) || serverType == ServerTypeSingle || serverType == ServerTypeResilientSingle {
 							hostPort, err := p.HostPort(port)
@@ -243,8 +249,10 @@ func (s *runtimeServerManager) runArangod(ctx context.Context, log *logging.Logg
 								s.logMutex.Unlock()
 							}
 						}
-					} else {
+					} else if !up {
 						log.Warningf("%s not ready after 5min!: Status trail: %#v", serverType, statusTrail)
+					} else if !correctRole {
+						log.Warningf("%s does not have the expected role of '%s,%s' (but '%s,%s'): Status trail: %#v", serverType, expectedRole, expectedMode, role, mode, statusTrail)
 					}
 				}
 			}()

--- a/service/server_type.go
+++ b/service/server_type.go
@@ -53,3 +53,21 @@ func (s ServerType) PortOffset() int {
 		panic(fmt.Sprintf("Unknown ServerType: %s", string(s)))
 	}
 }
+
+// ExpectedServerRole returns the expected `role` & `mode` value resulting from a request to `_admin/server/role`.
+func (s ServerType) ExpectedServerRole() (string, string) {
+	switch s {
+	case ServerTypeCoordinator:
+		return "COORDINATOR", ""
+	case ServerTypeSingle:
+		return "SINGLE", ""
+	case ServerTypeResilientSingle:
+		return "SINGLE", "resilient"
+	case ServerTypeDBServer:
+		return "PRIMARY", ""
+	case ServerTypeAgent:
+		return "AGENT", ""
+	default:
+		panic(fmt.Sprintf("Unknown ServerType: %s", string(s)))
+	}
+}

--- a/start.go
+++ b/start.go
@@ -136,7 +136,7 @@ func cmdStartRun(cmd *cobra.Command, args []string) {
 				allUp := true
 				for _, server := range list.Servers {
 					ctx, cancel := context.WithTimeout(rootCtx, time.Second)
-					up, _, _, _ := service.TestInstance(ctx, server.IP, server.Port, nil)
+					up, _, _, _, _, _, _ := service.TestInstance(ctx, server.IP, server.Port, "", "", nil)
 					cancel()
 					if !up {
 						allUp = false


### PR DESCRIPTION
fixes #100 

When there is already a single instance running on port 8529 and you use the starter to run a cluster, you get a message like this

```
2017/11/13 10:16:59 [e4c120b1] coordinator does not have the expected role of 'COORDINATOR,' (but 'SINGLE,'): Status trail: []int{}
```

It does not prevent other coordinators from trying to reach that single instance. 
Doing so would mean a complete new check system before all starters (running on various machines) can try to start anything. Even then it is not completely safe because between this new check and the time the starter starts the coordinator, a single instance could have been started also.
For me this new check is overkill for what we're trying to accomplish.

Will this be sufficient?