### PR TITLE
Logrotate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Changes from version 0.10.3 to master
+
+- Added support for log file rotation for started server components.
+
 # Changes from version 0.10.3 to 0.10.4
 
 - Using shard `http.Client` to reduce the number of used file descriptors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Added support for log file rotation for started server components.
 
-# Changes from version 0.10.3 to 0.10.4
+# Changes from version 0.10.4 to 0.10.4
 
 - Using shard `http.Client` to reduce the number of used file descriptors.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-# Changes from version 0.10.3 to master
+# Changes from version 0.10.4 to master
 
 - Added support for log file rotation for started server components.
 
-# Changes from version 0.10.4 to 0.10.4
+# Changes from version 0.10.3 to 0.10.4
 
 - Using shard `http.Client` to reduce the number of used file descriptors.
 

--- a/README.md
+++ b/README.md
@@ -492,7 +492,7 @@ show more information (default false).
 
 * `--log.rotate-files-to-keep=int`
 
-set the number of old log files to keep when rotating log files of server components.
+set the number of old log files to keep when rotating log files of server components (default 5).
 
 * `--log.rotate-interval=duration`
 

--- a/README.md
+++ b/README.md
@@ -490,6 +490,17 @@ debugging only.
 
 show more information (default false).
 
+* `--log.rotate-files-to-keep=int`
+
+set the number of old log files to keep when rotating log files of server components.
+
+* `--log.rotate-interval=duration`
+
+set the interval between rotations of log files of server components (default `24h`).
+Use a value of `0` to disable automatic log rotation.
+
+Note: The starter will always perform log rotation when it receives a `HUP` signal.
+
 * `--starter.unique-port-offsets=bool`
 
 If set to true, all port offsets (of slaves) will be made globally unique.

--- a/main.go
+++ b/main.go
@@ -49,9 +49,11 @@ import (
 // Configuration data with defaults:
 
 const (
-	projectName               = "arangodb"
-	defaultDockerGCDelay      = time.Minute * 10
-	defaultDockerStarterImage = "arangodb/arangodb-starter"
+	projectName                 = "arangodb"
+	defaultDockerGCDelay        = time.Minute * 10
+	defaultDockerStarterImage   = "arangodb/arangodb-starter"
+	defaultLogRotateFilesToKeep = 5
+	defaultLogRotateInterval    = time.Minute * 60 * 24
 )
 
 var (
@@ -98,6 +100,7 @@ var (
 	rocksDBEncryptionKeyFile string
 	disableIPv6              bool
 	logRotateFilesToKeep     int
+	logRotateInterval        time.Duration
 	dockerEndpoint           string
 	dockerImage              string
 	dockerImagePullPolicy    string
@@ -134,7 +137,8 @@ func init() {
 	f.BoolVar(&disableIPv6, "starter.disable-ipv6", !net.IsIPv6Supported(), "If set, no IPv6 notation will be used. Use this only when IPv6 address family is disabled")
 
 	f.BoolVar(&verbose, "log.verbose", false, "Turn on debug logging")
-	f.IntVar(&logRotateFilesToKeep, "log.rotate-files-to-keep", 5, "Number of files to keep when rotating log files")
+	f.IntVar(&logRotateFilesToKeep, "log.rotate-files-to-keep", defaultLogRotateFilesToKeep, "Number of files to keep when rotating log files")
+	f.DurationVar(&logRotateInterval, "log.rotate-interval", defaultLogRotateInterval, "Time between log rotations (0 disables log rotation)")
 
 	f.IntVar(&agencySize, "cluster.agency-size", 3, "Number of agents in the cluster")
 	f.BoolSliceVar(&startAgent, "cluster.start-agent", nil, "should an agent instance be started")
@@ -533,6 +537,7 @@ func mustPrepareService(generateAutoKeyFile bool) (*service.Service, service.Boo
 		Verbose:               verbose,
 		ServerThreads:         serverThreads,
 		LogRotateFilesToKeep:  logRotateFilesToKeep,
+		LogRotateInterval:     logRotateInterval,
 		AllPortOffsetsUnique:  allPortOffsetsUnique,
 		RunningInDocker:       isRunningInDocker(),
 		DockerContainerName:   dockerContainerName,

--- a/service/runner.go
+++ b/service/runner.go
@@ -69,6 +69,8 @@ type Process interface {
 	Terminate() error
 	// Kill performs a hard termination of the process
 	Kill() error
+	// Hup sends a SIGHUP to the process
+	Hup() error
 
 	// Remove all traces of this process
 	Cleanup() error

--- a/service/runner_docker.go
+++ b/service/runner_docker.go
@@ -486,6 +486,17 @@ func (p *dockerContainer) Kill() error {
 	return nil
 }
 
+// Hup sends a SIGHUP to the process
+func (p *dockerContainer) Hup() error {
+	if err := p.client.KillContainer(docker.KillContainerOptions{
+		ID:     p.container.ID,
+		Signal: docker.SIGHUP,
+	}); err != nil {
+		return maskAny(err)
+	}
+	return nil
+}
+
 func (p *dockerContainer) Cleanup() error {
 	opts := docker.RemoveContainerOptions{
 		ID:            p.container.ID,

--- a/service/runner_process.go
+++ b/service/runner_process.go
@@ -187,6 +187,15 @@ func (p *process) Kill() error {
 	return nil
 }
 
+func (p *process) Hup() error {
+	if proc := p.p; proc != nil {
+		if err := proc.Signal(syscall.SIGHUP); err != nil {
+			return maskAny(err)
+		}
+	}
+	return nil
+}
+
 // Remove all traces of this process
 func (p *process) Cleanup() error {
 	// Nothing todo here

--- a/service/runtime_server_manager.go
+++ b/service/runtime_server_manager.go
@@ -303,6 +303,78 @@ func (s *runtimeServerManager) runArangod(ctx context.Context, log *logging.Logg
 	}
 }
 
+// rotateLogFile rotates the log file of a single server.
+func (s *runtimeServerManager) rotateLogFile(ctx context.Context, log *logging.Logger, runtimeContext runtimeServerManagerContext, myPeer Peer, serverType ServerType, p Process, filesToKeep int) {
+	if p == nil {
+		return
+	}
+
+	// Prepare log path
+	myHostDir, err := runtimeContext.serverHostDir(serverType)
+	if err != nil {
+		log.Debugf("Failed to get host directory for '%s': %s", serverType, err)
+		return
+	}
+	logPath := filepath.Join(myHostDir, logFileName)
+	log.Debugf("Rotating %s log file: %s", serverType, logPath)
+
+	// Move old files
+	for i := filesToKeep; i >= 0; i-- {
+		var logPathX string
+		if i == 0 {
+			logPathX = logPath
+		} else {
+			logPathX = logPath + fmt.Sprintf(".%d", i)
+		}
+		if _, err := os.Stat(logPathX); err == nil {
+			if i == filesToKeep {
+				// Remove file
+				if err := os.Remove(logPathX); err != nil {
+					log.Errorf("Failed to remove %s: %s", logPathX, err)
+				} else {
+					log.Debugf("Removed old log file: %s", logPathX)
+				}
+			} else {
+				// Rename log[.i] -> log.i+1
+				logPathNext := logPath + fmt.Sprintf(".%d", i+1)
+				if err := os.Rename(logPathX, logPathNext); err != nil {
+					log.Errorf("Failed to move %s to %s: %s", logPathX, logPathNext, err)
+				} else {
+					log.Debugf("Moved log file %s to %s", logPathX, logPathNext)
+				}
+			}
+		}
+	}
+
+	// Send HUP signal
+	if err := p.Hup(); err != nil {
+		log.Errorf("Failed to send HUP signal: %s", err)
+	}
+	return
+}
+
+// RotateLogFiles rotates the log files of all servers
+func (s *runtimeServerManager) RotateLogFiles(ctx context.Context, log *logging.Logger, runtimeContext runtimeServerManagerContext, config Config) {
+	log.Info("Rotating log files...")
+	_, myPeer, _ := runtimeContext.ClusterConfig()
+	if myPeer == nil {
+		log.Error("Cannot find my own peer in cluster configuration")
+	} else {
+		if p := s.singleProc; p != nil {
+			s.rotateLogFile(ctx, log, runtimeContext, *myPeer, ServerTypeSingle, p, config.LogRotateFilesToKeep)
+		}
+		if p := s.coordinatorProc; p != nil {
+			s.rotateLogFile(ctx, log, runtimeContext, *myPeer, ServerTypeCoordinator, p, config.LogRotateFilesToKeep)
+		}
+		if p := s.dbserverProc; p != nil {
+			s.rotateLogFile(ctx, log, runtimeContext, *myPeer, ServerTypeDBServer, p, config.LogRotateFilesToKeep)
+		}
+		if p := s.agentProc; p != nil {
+			s.rotateLogFile(ctx, log, runtimeContext, *myPeer, ServerTypeAgent, p, config.LogRotateFilesToKeep)
+		}
+	}
+}
+
 // Run starts all relevant servers and keeps the running.
 func (s *runtimeServerManager) Run(ctx context.Context, log *logging.Logger, runtimeContext runtimeServerManagerContext, runner Runner, config Config, bsCfg BootstrapConfig) {
 	_, myPeer, mode := runtimeContext.ClusterConfig()

--- a/service/service.go
+++ b/service/service.go
@@ -60,6 +60,7 @@ type Config struct {
 	AllPortOffsetsUnique bool // If set, all peers will get a unique port offset. If false (default) only portOffset+peerAddress pairs will be unique.
 	PassthroughOptions   []PassthroughOption
 	DebugCluster         bool
+	LogRotateFilesToKeep int
 
 	DockerContainerName   string // Name of the container running this process
 	DockerEndpoint        string // Where to reach the docker daemon
@@ -770,6 +771,11 @@ func (s *Service) MasterChangedCallback() {
 	if s.state == stateRunningSlave {
 		go s.runtimeClusterManager.Interrupt()
 	}
+}
+
+// RotateLogFiles rotates the log files of all servers
+func (s *Service) RotateLogFiles(ctx context.Context) {
+	s.runtimeServerManager.RotateLogFiles(ctx, s.log, s, s.cfg)
 }
 
 func (s *Service) getHTTPServerPort() (containerPort, hostPort int, err error) {


### PR DESCRIPTION
Added support for rotating log files of started components.

- On `SIGHUP` 
- On interval specified by `--log.rotate-interval`