### PR TITLE
Database auto upgrade support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changes from version 0.10.4 to master
 
+- Added `POST /data-auto-upgrade` support to perform a rolling upgrade of all servers (with single `--database.auto-upgrade` restart)
 - Renamed mode option `resilientsingle` to `activefailover`. (`resilientsingle` is being supported as alias for a while)
 - Added support for log file rotation for started server components.
 - Added support for running datacenter to datacenter replication servers (`arangosync`) from the starter.

--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ $(BIN): $(GOBUILDDIR) $(SOURCES)
 		-e CGO_ENABLED=0 \
 		-w /usr/code/ \
 		golang:$(GOVERSION) \
-		go build -a -installsuffix netgo -tags netgo -ldflags "-X main.projectVersion=$(VERSION) -X main.projectBuild=$(COMMIT)" -o /usr/code/bin/$(GOOS)/$(GOARCH)/$(BINNAME) $(REPOPATH)
+		go build -installsuffix netgo -tags netgo -ldflags "-X main.projectVersion=$(VERSION) -X main.projectBuild=$(COMMIT)" -o /usr/code/bin/$(GOOS)/$(GOARCH)/$(BINNAME) $(REPOPATH)
 
 docker: build
 	docker build -t arangodb/arangodb-starter .

--- a/docs/http_api.md
+++ b/docs/http_api.md
@@ -166,6 +166,19 @@ Status codes:
 - 412 When this starter cannot be removed.
 - 503 When starter is not yet ready to be removed.
 
+### POST `/database-auto-upgrade`
+
+Initiates an upgrade process of all ArangoDB servers started by this starter.
+
+The request does not expect any input.
+
+Returns `OK` as text/plain on success.
+
+Status codes:
+
+- 200 On success
+- 412 When this starter cannot be start the upgrade process. Usually because another starter is already upgrading its servers.
+
 ## Internal API
 
 ### GET `/id` 

--- a/service/arangod/agency_health.go
+++ b/service/arangod/agency_health.go
@@ -67,6 +67,7 @@ func AreAgentsHealthy(ctx context.Context, clients []AgencyAPI) error {
 				} else {
 					// Unexpected / invalid response
 					statuses[i].IsResponding = false
+					//fmt.Printf("Agency response: %v\n", err)
 				}
 			}
 		}(i, c)

--- a/service/arangod/agency_health.go
+++ b/service/arangod/agency_health.go
@@ -1,0 +1,97 @@
+//
+// DISCLAIMER
+//
+// Copyright 2017 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+// Author Ewout Prangsma
+//
+
+package arangod
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+const (
+	maxAgentResponseTime = time.Second * 10
+)
+
+// agentStatus is a helper structure used in AreAgentsHealthy.
+type agentStatus struct {
+	IsLeader       bool
+	LeaderEndpoint string
+	IsResponding   bool
+}
+
+// AreAgentsHealthy performs a health check on all given agents.
+// Of the given agents, 1 must respond as leader and all others must redirect to the leader.
+// The function returns nil when all agents are healthy or an error when something is wrong.
+func AreAgentsHealthy(ctx context.Context, clients []AgencyAPI) error {
+	wg := sync.WaitGroup{}
+	invalidKey := []string{"does-not-exist-70ddb948-59ea-52f3-9a19-baaca18de7ae"}
+	statuses := make([]agentStatus, len(clients))
+	for i, c := range clients {
+		wg.Add(1)
+		go func(i int, c AgencyAPI) {
+			defer wg.Done()
+			lctx, cancel := context.WithTimeout(ctx, maxAgentResponseTime)
+			defer cancel()
+			if _, err := c.ReadKey(lctx, invalidKey); err == nil || IsKeyNotFound(err) {
+				// We got a valid read from the leader
+				statuses[i].IsLeader = true
+				statuses[i].LeaderEndpoint = c.Endpoint()
+				statuses[i].IsResponding = true
+			} else {
+				if location, ok := IsNotLeader(err); ok {
+					// Valid response from a follower
+					statuses[i].IsLeader = false
+					statuses[i].LeaderEndpoint = location
+					statuses[i].IsResponding = true
+				} else {
+					// Unexpected / invalid response
+					statuses[i].IsResponding = false
+				}
+			}
+		}(i, c)
+	}
+	wg.Wait()
+
+	// Check the results
+	noLeaders := 0
+	for i, status := range statuses {
+		if !status.IsResponding {
+			return maskAny(fmt.Errorf("Agent %s is not responding", clients[i].Endpoint()))
+		}
+		if status.IsLeader {
+			noLeaders++
+		}
+		if i > 0 {
+			// Compare leader endpoint with previous
+			prev := statuses[i-1].LeaderEndpoint
+			if !IsSameEndpoint(prev, status.LeaderEndpoint) {
+				return maskAny(fmt.Errorf("Not all agents report the same leader endpoint"))
+			}
+		}
+	}
+	if noLeaders != 1 {
+		return maskAny(fmt.Errorf("Unexpected number of agency leaders: %d", noLeaders))
+	}
+	return nil
+}

--- a/service/arangod/api.go
+++ b/service/arangod/api.go
@@ -50,12 +50,18 @@ type AgencyAPI interface {
 	// ReadKey reads the value of a given key in the agency.
 	ReadKey(ctx context.Context, key []string) (interface{}, error)
 
+	// WriteKey writes the given value with the given key.
+	WriteKey(ctx context.Context, key []string, value interface{}, ttl time.Duration) error
+
 	// WriteKeyIfEmpty writes the given value with the given key only if the key was empty before.
 	WriteKeyIfEmpty(ctx context.Context, key []string, value interface{}, ttl time.Duration) error
 
 	// WriteKeyIfEqualTo writes the given new value with the given key only if the existing value for that key equals
 	// to the given old value.
 	WriteKeyIfEqualTo(ctx context.Context, key []string, newValue, oldValue interface{}, ttl time.Duration) error
+
+	// RemoveKey removes the given key.
+	RemoveKey(ctx context.Context, key []string) error
 
 	// RemoveKeyIfEqualTo removes the given key only if the existing value for that key equals
 	// to the given old value.

--- a/service/arangod/client.go
+++ b/service/arangod/client.go
@@ -45,8 +45,9 @@ func NewServerClient(endpoint url.URL, prepareRequest func(*http.Request) error,
 		prepareRequest: prepareRequest,
 	}
 	if !followRedirects {
+
 		c.client.CheckRedirect = func(*http.Request, []*http.Request) error {
-			return maskAny(redirectionError)
+			return http.ErrUseLastResponse // Do not wrap, standard library will not understand
 		}
 	}
 	return c, nil
@@ -81,6 +82,11 @@ func (c *client) Server() (ServerAPI, error) {
 // Endpoints must be URL's of one or more coordinators of the cluster.
 func (c *client) Cluster() ClusterAPI {
 	return c
+}
+
+// Returns the endpoint of the specific agency this api targets.
+func (c *client) Endpoint() string {
+	return c.endpoint.String()
 }
 
 // ReadKey reads the value of a given key in the agency.
@@ -404,6 +410,35 @@ type idResponse struct {
 	ID string `json:"id,omitempty"`
 }
 
+// Gets the Version of this server.
+func (c *client) Version(ctx context.Context) (VersionInfo, error) {
+	url := c.createURL("/_api/version", nil)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return VersionInfo{}, maskAny(err)
+	}
+	if ctx != nil {
+		req = req.WithContext(ctx)
+	}
+	if c.prepareRequest != nil {
+		if err := c.prepareRequest(req); err != nil {
+			return VersionInfo{}, maskAny(err)
+		}
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return VersionInfo{}, maskAny(err)
+	}
+	var result VersionInfo
+	if err := c.handleResponse(resp, "GET", url, &result); err != nil {
+		return VersionInfo{}, maskAny(err)
+	}
+
+	// Success
+	return result, nil
+}
+
 // Gets the ID of this server in the cluster.
 // ID will be empty for single servers.
 func (c *client) ID(ctx context.Context) (string, error) {
@@ -563,6 +598,12 @@ func (c *client) handleResponse(resp *http.Response, method, url string, result 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return maskAny(errors.Wrapf(err, "Failed reading response data from %s request to %s: %v", method, url, err))
+	}
+
+	if resp.StatusCode == 307 {
+		// Not leader
+		location := resp.Header.Get("Location")
+		return NotLeaderError{Leader: location}
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {

--- a/service/arangod/error.go
+++ b/service/arangod/error.go
@@ -32,7 +32,6 @@ var (
 	maskAny              = errors.WithStack
 	ConditionFailedError = errors.New("Condition failed")
 	KeyNotFoundError     = errors.New("Key not found")
-	redirectionError     = errors.New("redirect")
 )
 
 type StatusError struct {
@@ -57,4 +56,24 @@ func IsConditionFailed(err error) bool {
 
 func IsKeyNotFound(err error) bool {
 	return errors.Cause(err) == KeyNotFoundError
+}
+
+// NotLeaderError indicates the response of an agent when it is
+// not the leader of the agency.
+type NotLeaderError struct {
+	Leader string // Endpoint of the current leader
+}
+
+// Error implements error.
+func (e NotLeaderError) Error() string {
+	return "not the leader"
+}
+
+// IsNotLeader returns true if the given error is (or is caused by) a NotLeaderError.
+func IsNotLeader(err error) (string, bool) {
+	nlErr, ok := err.(NotLeaderError)
+	if ok {
+		return nlErr.Leader, true
+	}
+	return "", false
 }

--- a/service/arangod/error.go
+++ b/service/arangod/error.go
@@ -58,6 +58,11 @@ func IsKeyNotFound(err error) bool {
 	return errors.Cause(err) == KeyNotFoundError
 }
 
+func IsPreconditionFailed(err error) bool {
+	statusCode, ok := IsStatusError(err)
+	return ok && statusCode == 412
+}
+
 // NotLeaderError indicates the response of an agent when it is
 // not the leader of the agency.
 type NotLeaderError struct {
@@ -71,7 +76,7 @@ func (e NotLeaderError) Error() string {
 
 // IsNotLeader returns true if the given error is (or is caused by) a NotLeaderError.
 func IsNotLeader(err error) (string, bool) {
-	nlErr, ok := err.(NotLeaderError)
+	nlErr, ok := errors.Cause(err).(NotLeaderError)
 	if ok {
 		return nlErr.Leader, true
 	}

--- a/service/arangod/lock.go
+++ b/service/arangod/lock.go
@@ -1,0 +1,194 @@
+//
+// DISCLAIMER
+//
+// Copyright 2017 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+// Author Ewout Prangsma
+//
+
+package arangod
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"sync"
+	"time"
+
+	logging "github.com/op/go-logging"
+)
+
+const (
+	minLockTTL = time.Second * 5
+)
+
+// Lock is an agency backed exclusive lock.
+type Lock interface {
+	// Lock tries to lock the lock.
+	// If it is not possible to lock, an error is returned.
+	// If the lock is already held by me, an error is returned.
+	Lock(ctx context.Context) error
+
+	// Unlock tries to unlock the lock.
+	// If it is not possible to unlock, an error is returned.
+	// If the lock is not held by me, an error is returned.
+	Unlock(ctx context.Context) error
+
+	// IsLocked return true if the lock is held by me.
+	IsLocked() bool
+}
+
+// NewLock creates a new lock on the given key.
+func NewLock(log *logging.Logger, api AgencyAPI, key []string, id string, ttl time.Duration) (Lock, error) {
+	if ttl < minLockTTL {
+		ttl = minLockTTL
+	}
+	if id == "" {
+		randBytes := make([]byte, 16)
+		rand.Read(randBytes)
+		id = hex.EncodeToString(randBytes)
+	}
+	return &lock{
+		log: log,
+		api: api,
+		key: key,
+		id:  id,
+		ttl: ttl,
+	}, nil
+}
+
+type lock struct {
+	mutex         sync.Mutex
+	log           *logging.Logger
+	api           AgencyAPI
+	key           []string
+	id            string
+	ttl           time.Duration
+	locked        bool
+	cancelRenewal func()
+}
+
+// Lock tries to lock the lock.
+// If it is not possible to lock, an error is returned.
+// If the lock is already held by me, an error is returned.
+func (l *lock) Lock(ctx context.Context) error {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	if l.locked {
+		return maskAny(AlreadyLockedError)
+	}
+
+	// Try to claim lock
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel()
+	if err := l.api.WriteKeyIfEmpty(ctx, l.key, l.id, l.ttl); err != nil {
+		return maskAny(err)
+	}
+
+	// Success
+	l.locked = true
+
+	// Keep renewing
+	renewCtx, renewCancel := context.WithCancel(context.Background())
+	go l.renewLock(renewCtx)
+	l.cancelRenewal = renewCancel
+
+	return nil
+}
+
+// Unlock tries to unlock the lock.
+// If it is not possible to unlock, an error is returned.
+// If the lock is not held by me, an error is returned.
+func (l *lock) Unlock(ctx context.Context) error {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	if !l.locked {
+		return maskAny(NotLockedError)
+	}
+
+	// Release the lock
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel()
+	if err := l.api.RemoveKeyIfEqualTo(ctx, l.key, l.id); err != nil {
+		return maskAny(err)
+	}
+
+	// Cleanup
+	l.locked = false
+	if l.cancelRenewal != nil {
+		l.cancelRenewal()
+		l.cancelRenewal = nil
+	}
+
+	return nil
+}
+
+// IsLocked return true if the lock is held by me.
+func (l *lock) IsLocked() bool {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	return l.locked
+}
+
+// renewLock keeps renewing the lock until the given context is canceled.
+func (l *lock) renewLock(ctx context.Context) {
+	// op performs a renewal once.
+	// returns stop, error
+	op := func() (bool, error) {
+		l.mutex.Lock()
+		defer l.mutex.Unlock()
+
+		if !l.locked {
+			return true, maskAny(NotLockedError)
+		}
+
+		// Update key in agency
+		ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+		defer cancel()
+		if err := l.api.WriteKeyIfEqualTo(ctx, l.key, l.id, l.id, l.ttl); err != nil {
+			if IsConditionFailed(err) {
+				// We're not longer the leader
+				l.locked = false
+				l.cancelRenewal = nil
+				return true, maskAny(err)
+			}
+			return false, maskAny(err)
+		}
+		return false, nil
+	}
+	for {
+		delay := l.ttl / 2
+		stop, err := op()
+		if err != nil {
+			l.log.Errorf("Failed to renew lock %s. %v", l.key, err)
+			delay = time.Second
+		}
+		if stop {
+			return
+		}
+
+		select {
+		case <-ctx.Done():
+			// we're done
+			return
+		case <-time.After(delay):
+			// Try to renew
+		}
+	}
+}

--- a/service/arangod/lock.go
+++ b/service/arangod/lock.go
@@ -97,6 +97,9 @@ func (l *lock) Lock(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 	defer cancel()
 	if err := l.api.WriteKeyIfEmpty(ctx, l.key, l.id, l.ttl); err != nil {
+		if IsPreconditionFailed(err) {
+			return maskAny(AlreadyLockedError)
+		}
 		return maskAny(err)
 	}
 

--- a/service/arangod/lock_errors.go
+++ b/service/arangod/lock_errors.go
@@ -1,0 +1,40 @@
+//
+// DISCLAIMER
+//
+// Copyright 2018 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+// Author Ewout Prangsma
+//
+
+package arangod
+
+import (
+	"github.com/pkg/errors"
+)
+
+var (
+	AlreadyLockedError = errors.New("already locked")
+	NotLockedError     = errors.New("not locked")
+)
+
+func IsAlreadyLocked(err error) bool {
+	return errors.Cause(err) == AlreadyLockedError
+}
+
+func IsNotLocked(err error) bool {
+	return errors.Cause(err) == NotLockedError
+}

--- a/service/arangod/multi_client.go
+++ b/service/arangod/multi_client.go
@@ -94,6 +94,20 @@ func (c *multiClient) ReadKey(ctx context.Context, key []string) (interface{}, e
 	}
 }
 
+// WriteKey writes the given value with the given key.
+func (c *multiClient) WriteKey(ctx context.Context, key []string, value interface{}, ttl time.Duration) error {
+	op := func(ctx context.Context, c API) (interface{}, error) {
+		if err := c.Agency().WriteKey(ctx, key, value, ttl); err != nil {
+			return nil, maskAny(err)
+		}
+		return nil, nil
+	}
+	if _, err := c.handleMultiRequests(ctx, op); err != nil {
+		return maskAny(err)
+	}
+	return nil
+}
+
 // WriteKeyIfEmpty writes the given value with the given key only if the key was empty before.
 func (c *multiClient) WriteKeyIfEmpty(ctx context.Context, key []string, value interface{}, ttl time.Duration) error {
 	op := func(ctx context.Context, c API) (interface{}, error) {
@@ -113,6 +127,20 @@ func (c *multiClient) WriteKeyIfEmpty(ctx context.Context, key []string, value i
 func (c *multiClient) WriteKeyIfEqualTo(ctx context.Context, key []string, newValue, oldValue interface{}, ttl time.Duration) error {
 	op := func(ctx context.Context, c API) (interface{}, error) {
 		if err := c.Agency().WriteKeyIfEqualTo(ctx, key, newValue, oldValue, ttl); err != nil {
+			return nil, maskAny(err)
+		}
+		return nil, nil
+	}
+	if _, err := c.handleMultiRequests(ctx, op); err != nil {
+		return maskAny(err)
+	}
+	return nil
+}
+
+// RemoveKey removes the given key
+func (c *multiClient) RemoveKey(ctx context.Context, key []string) error {
+	op := func(ctx context.Context, c API) (interface{}, error) {
+		if err := c.Agency().RemoveKey(ctx, key); err != nil {
 			return nil, maskAny(err)
 		}
 		return nil, nil

--- a/service/arangod/multi_client.go
+++ b/service/arangod/multi_client.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 )
@@ -49,6 +50,15 @@ func NewClusterClient(endpoints []url.URL, prepareRequest func(*http.Request) er
 
 type multiClient struct {
 	clients []API
+}
+
+// Returns the endpoint of the specific agency this api targets.
+func (c *multiClient) Endpoint() string {
+	result := make([]string, 0, len(c.clients))
+	for _, c := range c.clients {
+		result = append(result, c.Agency().Endpoint())
+	}
+	return strings.Join(result, ",")
 }
 
 // Agency returns API of the agency

--- a/service/arangod_config_builder.go
+++ b/service/arangod_config_builder.go
@@ -130,7 +130,7 @@ func createArangodConf(log *logging.Logger, bsCfg BootstrapConfig, myHostDir, my
 
 // createArangodArgs returns the command line arguments needed to run an arangod server of given type.
 func createArangodArgs(log *logging.Logger, config Config, clusterConfig ClusterConfig, myContainerDir string,
-	myPeerID, myAddress, myPort string, serverType ServerType, arangodConfig configFile, agentRecoveryID string) []string {
+	myPeerID, myAddress, myPort string, serverType ServerType, arangodConfig configFile, agentRecoveryID string, databaseAutoUpgrade bool) []string {
 	containerConfFileName := filepath.Join(myContainerDir, arangodConfFileName)
 
 	args := make([]string, 0, 40)

--- a/service/arangod_config_builder.go
+++ b/service/arangod_config_builder.go
@@ -152,6 +152,10 @@ func createArangodArgs(log *logging.Logger, config Config, clusterConfig Cluster
 		optionPair{"--log.file", slasher(filepath.Join(myContainerDir, arangodLogFileName))},
 		optionPair{"--log.force-direct", "false"},
 	)
+	if databaseAutoUpgrade {
+		options = append(options,
+			optionPair{"--database.auto-upgrade", "true"})
+	}
 	if config.ServerThreads != 0 {
 		options = append(options,
 			optionPair{"--server.threads", strconv.Itoa(config.ServerThreads)})

--- a/service/cluster_config.go
+++ b/service/cluster_config.go
@@ -225,6 +225,24 @@ func (p ClusterConfig) GetAgentEndpoints() ([]url.URL, error) {
 	return endpoints, nil
 }
 
+// GetDBServerEndpoints creates a list of URL's for all dbservers.
+func (p ClusterConfig) GetDBServerEndpoints() ([]url.URL, error) {
+	// Build endpoint list
+	var endpoints []url.URL
+	for _, p := range p.AllPeers {
+		if p.HasDBServer() {
+			port := p.Port + p.PortOffset + ServerType(ServerTypeDBServer).PortOffset()
+			scheme := NewURLSchemes(p.IsSecure).Browser
+			u, err := url.Parse(fmt.Sprintf("%s://%s", scheme, net.JoinHostPort(p.Address, strconv.Itoa(port))))
+			if err != nil {
+				return nil, maskAny(err)
+			}
+			endpoints = append(endpoints, *u)
+		}
+	}
+	return endpoints, nil
+}
+
 // GetCoordinatorEndpoints creates a list of URL's for all coordinators.
 func (p ClusterConfig) GetCoordinatorEndpoints() ([]url.URL, error) {
 	// Build endpoint list
@@ -232,6 +250,24 @@ func (p ClusterConfig) GetCoordinatorEndpoints() ([]url.URL, error) {
 	for _, p := range p.AllPeers {
 		if p.HasCoordinator() {
 			port := p.Port + p.PortOffset + ServerType(ServerTypeCoordinator).PortOffset()
+			scheme := NewURLSchemes(p.IsSecure).Browser
+			u, err := url.Parse(fmt.Sprintf("%s://%s", scheme, net.JoinHostPort(p.Address, strconv.Itoa(port))))
+			if err != nil {
+				return nil, maskAny(err)
+			}
+			endpoints = append(endpoints, *u)
+		}
+	}
+	return endpoints, nil
+}
+
+// GetSingleEndpoints creates a list of URL's for all single servers.
+func (p ClusterConfig) GetSingleEndpoints(all bool) ([]url.URL, error) {
+	// Build endpoint list
+	var endpoints []url.URL
+	for _, p := range p.AllPeers {
+		if all || p.HasResilientSingle() {
+			port := p.Port + p.PortOffset + ServerType(ServerTypeSingle).PortOffset()
 			scheme := NewURLSchemes(p.IsSecure).Browser
 			u, err := url.Parse(fmt.Sprintf("%s://%s", scheme, net.JoinHostPort(p.Address, strconv.Itoa(port))))
 			if err != nil {

--- a/service/mode.go
+++ b/service/mode.go
@@ -48,3 +48,8 @@ func (m ServiceMode) SupportsArangoSync() bool {
 func (m ServiceMode) SupportsRecovery() bool {
 	return m == "" || m.IsClusterMode() || m.IsActiveFailoverMode()
 }
+
+// HasAgency returns true when the given mode involves an agency.
+func (m ServiceMode) HasAgency() bool {
+	return !m.IsSingleMode()
+}

--- a/service/runtime_server_manager.go
+++ b/service/runtime_server_manager.go
@@ -63,6 +63,9 @@ type runtimeServerManagerContext interface {
 	// removeRecoveryFile removes any recorded RECOVERY file.
 	removeRecoveryFile()
 
+	// UpgradeManager returns the upgrade manager service.
+	UpgradeManager() UpgradeManager
+
 	// TestInstance checks the `up` status of an arangod server instance.
 	TestInstance(ctx context.Context, serverType ServerType, address string, port int,
 		statusChanged chan StatusItem) (up, correctRole bool, version, role, mode string, statusTrail []int, cancelled bool)
@@ -142,7 +145,9 @@ func startServer(ctx context.Context, log *logging.Logger, runtimeContext runtim
 
 	// Create server command line arguments
 	clusterConfig, myPeer, _ := runtimeContext.ClusterConfig()
-	args, err := createServerArgs(log, config, clusterConfig, myContainerDir, myPeer.ID, myHostAddress, strconv.Itoa(myPort), serverType, arangodConfig, containerSecretFileName, bsCfg.RecoveryAgentID)
+	upgradeManager := runtimeContext.UpgradeManager()
+	databaseAutoUpgrade := upgradeManager.ServerDatabaseAutoUpgrade(serverType)
+	args, err := createServerArgs(log, config, clusterConfig, myContainerDir, myPeer.ID, myHostAddress, strconv.Itoa(myPort), serverType, arangodConfig, containerSecretFileName, bsCfg.RecoveryAgentID, databaseAutoUpgrade)
 	if err != nil {
 		return nil, false, maskAny(err)
 	}
@@ -159,6 +164,10 @@ func startServer(ctx context.Context, log *logging.Logger, runtimeContext runtim
 	p, err = runner.Start(ctx, processType, args[0], args[1:], vols, ports, containerName, myHostDir)
 	if err != nil {
 		return nil, false, maskAny(err)
+	}
+	if databaseAutoUpgrade {
+		// Notify the context that we've succesfully started a server with database.auto-upgrade on.
+		upgradeManager.ServerDatabaseAutoUpgradeStarter(serverType)
 	}
 	return p, false, nil
 }
@@ -533,4 +542,36 @@ func (s *runtimeServerManager) Run(ctx context.Context, log *logging.Logger, run
 	if err := runner.Cleanup(); err != nil {
 		log.Warningf("Failed to cleanup runner: %v", err)
 	}
+}
+
+// RestartServer triggers a restart of the server of the given type.
+func (s *runtimeServerManager) RestartServer(log *logging.Logger, serverType ServerType) error {
+	var p Process
+	var name string
+	switch serverType {
+	case ServerTypeAgent:
+		p = s.agentProc
+		name = "agent"
+	case ServerTypeDBServer:
+		p = s.dbserverProc
+		name = "dbserver"
+	case ServerTypeCoordinator:
+		p = s.coordinatorProc
+		name = "coordinator"
+	case ServerTypeSingle:
+		p = s.singleProc
+		name = "single server"
+	case ServerTypeSyncMaster:
+		p = s.syncMasterProc
+		name = "sync master"
+	case ServerTypeSyncWorker:
+		p = s.syncWorkerProc
+		name = "sync worker"
+	default:
+		return maskAny(fmt.Errorf("Unknown server type '%s'", serverType))
+	}
+	if p != nil {
+		terminateProcess(log, p, name, time.Minute)
+	}
+	return nil
 }

--- a/service/server_config_builder.go
+++ b/service/server_config_builder.go
@@ -75,10 +75,10 @@ func collectServerConfigVolumes(serverType ServerType, config configFile) []Volu
 // createServerArgs returns the command line arguments needed to run an arangod/arangosync server of given type.
 func createServerArgs(log *logging.Logger, config Config, clusterConfig ClusterConfig, myContainerDir string,
 	myPeerID, myAddress, myPort string, serverType ServerType, arangodConfig configFile,
-	clusterJWTSecretFile, agentRecoveryID string) ([]string, error) {
+	clusterJWTSecretFile, agentRecoveryID string, databaseAutoUpgrade bool) ([]string, error) {
 	switch serverType.ProcessType() {
 	case ProcessTypeArangod:
-		return createArangodArgs(log, config, clusterConfig, myContainerDir, myPeerID, myAddress, myPort, serverType, arangodConfig, agentRecoveryID), nil
+		return createArangodArgs(log, config, clusterConfig, myContainerDir, myPeerID, myAddress, myPort, serverType, arangodConfig, agentRecoveryID, databaseAutoUpgrade), nil
 	case ProcessTypeArangoSync:
 		return createArangoSyncArgs(log, config, clusterConfig, myContainerDir, myPeerID, myAddress, myPort, serverType, clusterJWTSecretFile)
 	default:

--- a/service/upgrade_manager.go
+++ b/service/upgrade_manager.go
@@ -1,0 +1,374 @@
+//
+// DISCLAIMER
+//
+// Copyright 2017 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+// Author Ewout Prangsma
+//
+
+package service
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"time"
+
+	logging "github.com/op/go-logging"
+
+	"github.com/arangodb-helper/arangodb/service/arangod"
+)
+
+// UpgradeManager is the API of a service used to control the upgrade process from 1 database version to the next.
+type UpgradeManager interface {
+	// StartDatabaseUpgrade is called to start the upgrade process
+	StartDatabaseUpgrade() error
+
+	// ServerDatabaseAutoUpgrade returns true if the server of given type must be started with --database.auto-upgrade
+	ServerDatabaseAutoUpgrade(serverType ServerType) bool
+
+	// ServerDatabaseAutoUpgradeStarter is called when a server of given type has been be started with --database.auto-upgrade
+	ServerDatabaseAutoUpgradeStarter(serverType ServerType)
+}
+
+// UpgradeManagerContext holds methods used by the upgrade manager to control its context.
+type UpgradeManagerContext interface {
+	// ClusterConfig returns the current cluster configuration and the current peer
+	ClusterConfig() (ClusterConfig, *Peer, ServiceMode)
+	// PrepareDatabaseServerRequestFunc returns a function that is used to
+	// prepare a request to a database server (including authentication).
+	PrepareDatabaseServerRequestFunc() func(*http.Request) error
+	// RestartServer triggers a restart of the server of the given type.
+	RestartServer(serverType ServerType) error
+}
+
+// NewUpgradeManager creates a new upgrade manager.
+func NewUpgradeManager(log *logging.Logger, upgradeManagerContext UpgradeManagerContext) UpgradeManager {
+	return &upgradeManager{
+		log: log,
+		upgradeManagerContext: upgradeManagerContext,
+	}
+}
+
+var (
+	upgradeManagerLockKey = []string{"arangodb-helper", "arangodb", "upgrade-manager"}
+)
+
+const (
+	upgradeManagerLockTTL = time.Minute * 5
+)
+
+// upgradeManager is a helper used to control the upgrade process from 1 database version to the next.
+type upgradeManager struct {
+	mutex                 sync.Mutex
+	log                   *logging.Logger
+	upgradeManagerContext UpgradeManagerContext
+	upgradeServerType     ServerType
+}
+
+// StartDatabaseUpgrade is called to start the upgrade process
+func (m *upgradeManager) StartDatabaseUpgrade() error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	// Fetch mode
+	_, _, mode := m.upgradeManagerContext.ClusterConfig()
+
+	// Create lock (if needed)
+	ctx := context.Background()
+	var lock arangod.Lock
+	if mode.HasAgency() {
+		api, err := m.createAgencyAPI()
+		if err != nil {
+			return maskAny(err)
+		}
+		lock, err = arangod.NewLock(m.log, api, upgradeManagerLockKey, "", upgradeManagerLockTTL)
+		if err != nil {
+			return maskAny(err)
+		}
+
+		// Claim the upgrade lock
+		if err := lock.Lock(ctx); err != nil {
+			return maskAny(err)
+		}
+	}
+
+	// Run the upgrade process
+	go m.runUpgradeProcess(ctx, mode, lock)
+
+	return nil
+}
+
+// serverDatabaseAutoUpgrade returns true if the server of given type must be started with --database.auto-upgrade
+func (m *upgradeManager) ServerDatabaseAutoUpgrade(serverType ServerType) bool {
+	return m.upgradeServerType == serverType
+}
+
+// serverDatabaseAutoUpgradeStarter is called when a server of given type has been be started with --database.auto-upgrade
+func (m *upgradeManager) ServerDatabaseAutoUpgradeStarter(serverType ServerType) {
+	if m.upgradeServerType == serverType {
+		m.upgradeServerType = ""
+	}
+}
+
+// Create a client for the agency
+func (m *upgradeManager) createAgencyAPI() (arangod.AgencyAPI, error) {
+	prepareReq := m.upgradeManagerContext.PrepareDatabaseServerRequestFunc()
+	// Get cluster config
+	clusterConfig, _, _ := m.upgradeManagerContext.ClusterConfig()
+	// Create client
+	return clusterConfig.CreateAgencyAPI(prepareReq)
+}
+
+// runUpgradeProcess runs the entire upgrade process until it is finished.
+func (m *upgradeManager) runUpgradeProcess(ctx context.Context, mode ServiceMode, lock arangod.Lock) {
+	// Unlock when we're done
+	defer func() {
+		m.upgradeServerType = ""
+		if lock != nil {
+			lock.Unlock(context.Background())
+		}
+	}()
+
+	if mode.HasAgency() {
+		// First wait for the agency to be health
+		if err := m.waitUntil(ctx, m.isAgencyHealth, "Agency is not yet healthy: %v"); err != nil {
+			return
+		}
+
+		// Restart the agency in auto-upgrade mode
+		m.log.Info("Upgrading agent")
+		m.upgradeServerType = ServerTypeAgent
+		if err := m.upgradeManagerContext.RestartServer(ServerTypeAgent); err != nil {
+			m.log.Errorf("Failed to restart agent: %v", err)
+			return
+		}
+
+		// Wait until agency restarted
+		if err := m.waitUntilUpgradeServerStarted(ctx); err != nil {
+			return
+		}
+
+		// Wait until agency happy again
+		if err := m.waitUntil(ctx, m.isAgencyHealth, "Agency is not yet healthy: %v"); err != nil {
+			return
+		}
+	}
+
+	if mode.IsSingleMode() || mode.IsActiveFailoverMode() {
+		// Restart the single server in auto-upgrade mode
+		m.log.Info("Upgrading single server")
+		m.upgradeServerType = ServerTypeSingle
+		if err := m.upgradeManagerContext.RestartServer(ServerTypeSingle); err != nil {
+			m.log.Errorf("Failed to restart single server: %v", err)
+			return
+		}
+
+		// Wait until single server restarted
+		if err := m.waitUntilUpgradeServerStarted(ctx); err != nil {
+			return
+		}
+
+		// Wait until all single servers respond
+		if err := m.waitUntil(ctx, m.areSingleServersResponding, "Single server is not yet responding: %v"); err != nil {
+			return
+		}
+	} else if mode.IsClusterMode() {
+		// Restart the dbserver in auto-upgrade mode
+		m.log.Info("Upgrading dbserver")
+		m.upgradeServerType = ServerTypeDBServer
+		if err := m.upgradeManagerContext.RestartServer(ServerTypeDBServer); err != nil {
+			m.log.Errorf("Failed to restart dbserver: %v", err)
+			return
+		}
+
+		// Wait until dbserver restarted
+		if err := m.waitUntilUpgradeServerStarted(ctx); err != nil {
+			return
+		}
+
+		// Wait until all dbservers respond
+		if err := m.waitUntil(ctx, m.areDBServersResponding, "DBServers are not yet all responding: %v"); err != nil {
+			return
+		}
+
+		// Restart the coordinator in auto-upgrade mode
+		m.log.Info("Upgrading coordinator")
+		m.upgradeServerType = ServerTypeCoordinator
+		if err := m.upgradeManagerContext.RestartServer(ServerTypeCoordinator); err != nil {
+			m.log.Errorf("Failed to restart coordinator: %v", err)
+			return
+		}
+
+		// Wait until coordinator restarted
+		if err := m.waitUntilUpgradeServerStarted(ctx); err != nil {
+			return
+		}
+
+		// Wait until all coordinators respond
+		if err := m.waitUntil(ctx, m.areCoordinatorsResponding, "Coordinator are not yet all responding: %v"); err != nil {
+			return
+		}
+	}
+
+	// We're done
+	m.log.Info("Upgrading done.")
+}
+
+// waitUntilUpgradeServerStarted waits until the upgradeServerType field is empty.
+func (m *upgradeManager) waitUntilUpgradeServerStarted(ctx context.Context) error {
+	for {
+		if m.upgradeServerType == "" {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return maskAny(ctx.Err())
+		case <-time.After(time.Millisecond * 100):
+			// Try again
+		}
+	}
+}
+
+// waitUntil loops until the the given predicate returns nil or the given context is
+// canceled.
+// Returns nil when agency is completely healthy, an error otherwise.
+func (m *upgradeManager) waitUntil(ctx context.Context, predicate func(ctx context.Context) error, errorLogTemplate string) error {
+	for {
+		err := predicate(ctx)
+		if err == nil {
+			return nil
+		}
+		m.log.Infof(errorLogTemplate, err)
+		select {
+		case <-ctx.Done():
+			return maskAny(ctx.Err())
+		case <-time.After(time.Second * 5):
+			// Try again
+		}
+	}
+}
+
+// isAgencyHealth performs a check if the agency is healthy.
+// Returns nil when agency is completely healthy, an error
+// when the agency is not healthy or its health state could not
+// be determined.
+func (m *upgradeManager) isAgencyHealth(ctx context.Context) error {
+	prepareReq := m.upgradeManagerContext.PrepareDatabaseServerRequestFunc()
+	// Get cluster config
+	clusterConfig, _, _ := m.upgradeManagerContext.ClusterConfig()
+	// Build endpoint list
+	endpoints, err := clusterConfig.GetAgentEndpoints()
+	if err != nil {
+		return maskAny(err)
+	}
+	// Build agency clients
+	clients := make([]arangod.AgencyAPI, 0, len(endpoints))
+	for _, ep := range endpoints {
+		c, err := arangod.NewServerClient(ep, prepareReq, false)
+		if err != nil {
+			return maskAny(err)
+		}
+		clients = append(clients, c.Agency())
+	}
+	// Check health
+	if err := arangod.AreAgentsHealthy(ctx, clients); err != nil {
+		return maskAny(err)
+	}
+	return nil
+}
+
+// areDBServersResponding performs a check if all dbservers are responding.
+func (m *upgradeManager) areDBServersResponding(ctx context.Context) error {
+	prepareReq := m.upgradeManagerContext.PrepareDatabaseServerRequestFunc()
+	// Get cluster config
+	clusterConfig, _, _ := m.upgradeManagerContext.ClusterConfig()
+	// Build endpoint list
+	endpoints, err := clusterConfig.GetDBServerEndpoints()
+	if err != nil {
+		return maskAny(err)
+	}
+	// Check all
+	for _, ep := range endpoints {
+		c, err := arangod.NewServerClient(ep, prepareReq, false)
+		if err != nil {
+			return maskAny(err)
+		}
+		sa, err := c.Server()
+		if err != nil {
+			return maskAny(err)
+		}
+		if _, err := sa.ID(ctx); err != nil {
+			return maskAny(err)
+		}
+	}
+	return nil
+}
+
+// areCoordinatorsResponding performs a check if all coordinators are responding.
+func (m *upgradeManager) areCoordinatorsResponding(ctx context.Context) error {
+	prepareReq := m.upgradeManagerContext.PrepareDatabaseServerRequestFunc()
+	// Get cluster config
+	clusterConfig, _, _ := m.upgradeManagerContext.ClusterConfig()
+	// Build endpoint list
+	endpoints, err := clusterConfig.GetCoordinatorEndpoints()
+	if err != nil {
+		return maskAny(err)
+	}
+	// Check all
+	for _, ep := range endpoints {
+		c, err := arangod.NewServerClient(ep, prepareReq, false)
+		if err != nil {
+			return maskAny(err)
+		}
+		sa, err := c.Server()
+		if err != nil {
+			return maskAny(err)
+		}
+		if _, err := sa.ID(ctx); err != nil {
+			return maskAny(err)
+		}
+	}
+	return nil
+}
+
+// areSingleServersResponding performs a check if all single servers are responding.
+func (m *upgradeManager) areSingleServersResponding(ctx context.Context) error {
+	prepareReq := m.upgradeManagerContext.PrepareDatabaseServerRequestFunc()
+	// Get cluster config
+	clusterConfig, _, mode := m.upgradeManagerContext.ClusterConfig()
+	// Build endpoint list
+	endpoints, err := clusterConfig.GetSingleEndpoints(mode.IsSingleMode())
+	if err != nil {
+		return maskAny(err)
+	}
+	// Check all
+	for _, ep := range endpoints {
+		c, err := arangod.NewServerClient(ep, prepareReq, false)
+		if err != nil {
+			return maskAny(err)
+		}
+		sa, err := c.Server()
+		if err != nil {
+			return maskAny(err)
+		}
+		if _, err := sa.Version(ctx); err != nil {
+			return maskAny(err)
+		}
+	}
+	return nil
+}

--- a/service/upgrade_manager.go
+++ b/service/upgrade_manager.go
@@ -92,17 +92,21 @@ func (m *upgradeManager) StartDatabaseUpgrade() error {
 	ctx := context.Background()
 	var lock arangod.Lock
 	if mode.HasAgency() {
+		m.log.Debug("Creating agency API")
 		api, err := m.createAgencyAPI()
 		if err != nil {
 			return maskAny(err)
 		}
+		m.log.Debug("Creating lock")
 		lock, err = arangod.NewLock(m.log, api, upgradeManagerLockKey, "", upgradeManagerLockTTL)
 		if err != nil {
 			return maskAny(err)
 		}
 
 		// Claim the upgrade lock
+		m.log.Debug("Locking lock")
 		if err := lock.Lock(ctx); err != nil {
+			m.log.Debugf("Lock failed: %v", err)
 			return maskAny(err)
 		}
 	}

--- a/vendor/github.com/ryanuber/columnize/.travis.yml
+++ b/vendor/github.com/ryanuber/columnize/.travis.yml
@@ -1,0 +1,3 @@
+language: go
+go:
+  - tip

--- a/vendor/github.com/ryanuber/columnize/LICENSE
+++ b/vendor/github.com/ryanuber/columnize/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2016 Ryan Uber
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/ryanuber/columnize/README.md
+++ b/vendor/github.com/ryanuber/columnize/README.md
@@ -1,0 +1,71 @@
+Columnize
+=========
+
+Easy column-formatted output for golang
+
+[![Build Status](https://travis-ci.org/ryanuber/columnize.svg)](https://travis-ci.org/ryanuber/columnize)
+[![GoDoc](https://godoc.org/github.com/ryanuber/columnize?status.svg)](https://godoc.org/github.com/ryanuber/columnize)
+
+Columnize is a really small Go package that makes building CLI's a little bit
+easier. In some CLI designs, you want to output a number similar items in a
+human-readable way with nicely aligned columns. However, figuring out how wide
+to make each column is a boring problem to solve and eats your valuable time.
+
+Here is an example:
+
+```go
+package main
+
+import (
+    "fmt"
+    "github.com/ryanuber/columnize"
+)
+
+func main() {
+    output := []string{
+        "Name | Gender | Age",
+        "Bob | Male | 38",
+        "Sally | Female | 26",
+    }
+    result := columnize.SimpleFormat(output)
+    fmt.Println(result)
+}
+```
+
+As you can see, you just pass in a list of strings. And the result:
+
+```
+Name   Gender  Age
+Bob    Male    38
+Sally  Female  26
+```
+
+Columnize is tolerant of missing or empty fields, or even empty lines, so
+passing in extra lines for spacing should show up as you would expect.
+
+Configuration
+=============
+
+Columnize is configured using a `Config`, which can be obtained by calling the
+`DefaultConfig()` method. You can then tweak the settings in the resulting
+`Config`:
+
+```
+config := columnize.DefaultConfig()
+config.Delim = "|"
+config.Glue = "  "
+config.Prefix = ""
+config.Empty = ""
+config.NoTrim = false
+```
+
+* `Delim` is the string by which columns of **input** are delimited
+* `Glue` is the string by which columns of **output** are delimited
+* `Prefix` is a string by which each line of **output** is prefixed
+* `Empty` is a string used to replace blank values found in output
+* `NoTrim` is a boolean used to disable the automatic trimming of input values
+
+You can then pass the `Config` in using the `Format` method (signature below) to
+have text formatted to your liking.
+
+See the [godoc](https://godoc.org/github.com/ryanuber/columnize) page for usage.

--- a/vendor/github.com/ryanuber/columnize/columnize.go
+++ b/vendor/github.com/ryanuber/columnize/columnize.go
@@ -1,0 +1,191 @@
+package columnize
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+)
+
+// Config can be used to tune certain parameters which affect the way
+// in which Columnize will format output text.
+type Config struct {
+	// The string by which the lines of input will be split.
+	Delim string
+
+	// The string by which columns of output will be separated.
+	Glue string
+
+	// The string by which columns of output will be prefixed.
+	Prefix string
+
+	// A replacement string to replace empty fields.
+	Empty string
+
+	// NoTrim disables automatic trimming of inputs.
+	NoTrim bool
+}
+
+// DefaultConfig returns a *Config with default values.
+func DefaultConfig() *Config {
+	return &Config{
+		Delim:  "|",
+		Glue:   "  ",
+		Prefix: "",
+		Empty:  "",
+		NoTrim: false,
+	}
+}
+
+// MergeConfig merges two config objects together and returns the resulting
+// configuration. Values from the right take precedence over the left side.
+func MergeConfig(a, b *Config) *Config {
+	// Return quickly if either side was nil
+	if a == nil {
+		return b
+	}
+	if b == nil {
+		return a
+	}
+
+	var result Config = *a
+
+	if b.Delim != "" {
+		result.Delim = b.Delim
+	}
+	if b.Glue != "" {
+		result.Glue = b.Glue
+	}
+	if b.Prefix != "" {
+		result.Prefix = b.Prefix
+	}
+	if b.Empty != "" {
+		result.Empty = b.Empty
+	}
+	if b.NoTrim {
+		result.NoTrim = true
+	}
+
+	return &result
+}
+
+// stringFormat, given a set of column widths and the number of columns in
+// the current line, returns a sprintf-style format string which can be used
+// to print output aligned properly with other lines using the same widths set.
+func stringFormat(c *Config, widths []int, columns int) string {
+	// Create the buffer with an estimate of the length
+	buf := bytes.NewBuffer(make([]byte, 0, (6+len(c.Glue))*columns))
+
+	// Start with the prefix, if any was given. The buffer will not return an
+	// error so it does not need to be handled
+	buf.WriteString(c.Prefix)
+
+	// Create the format string from the discovered widths
+	for i := 0; i < columns && i < len(widths); i++ {
+		if i == columns-1 {
+			buf.WriteString("%s\n")
+		} else {
+			fmt.Fprintf(buf, "%%-%ds%s", widths[i], c.Glue)
+		}
+	}
+	return buf.String()
+}
+
+// elementsFromLine returns a list of elements, each representing a single
+// item which will belong to a column of output.
+func elementsFromLine(config *Config, line string) []interface{} {
+	separated := strings.Split(line, config.Delim)
+	elements := make([]interface{}, len(separated))
+	for i, field := range separated {
+		value := field
+		if !config.NoTrim {
+			value = strings.TrimSpace(field)
+		}
+
+		// Apply the empty value, if configured.
+		if value == "" && config.Empty != "" {
+			value = config.Empty
+		}
+		elements[i] = value
+	}
+	return elements
+}
+
+// runeLen calculates the number of visible "characters" in a string
+func runeLen(s string) int {
+	l := 0
+	for _ = range s {
+		l++
+	}
+	return l
+}
+
+// widthsFromLines examines a list of strings and determines how wide each
+// column should be considering all of the elements that need to be printed
+// within it.
+func widthsFromLines(config *Config, lines []string) []int {
+	widths := make([]int, 0, 8)
+
+	for _, line := range lines {
+		elems := elementsFromLine(config, line)
+		for i := 0; i < len(elems); i++ {
+			l := runeLen(elems[i].(string))
+			if len(widths) <= i {
+				widths = append(widths, l)
+			} else if widths[i] < l {
+				widths[i] = l
+			}
+		}
+	}
+	return widths
+}
+
+// Format is the public-facing interface that takes a list of strings and
+// returns nicely aligned column-formatted text.
+func Format(lines []string, config *Config) string {
+	conf := MergeConfig(DefaultConfig(), config)
+	widths := widthsFromLines(conf, lines)
+
+	// Estimate the buffer size
+	glueSize := len(conf.Glue)
+	var size int
+	for _, w := range widths {
+		size += w + glueSize
+	}
+	size *= len(lines)
+
+	// Create the buffer
+	buf := bytes.NewBuffer(make([]byte, 0, size))
+
+	// Create a cache for the string formats
+	fmtCache := make(map[int]string, 16)
+
+	// Create the formatted output using the format string
+	for _, line := range lines {
+		elems := elementsFromLine(conf, line)
+
+		// Get the string format using cache
+		numElems := len(elems)
+		stringfmt, ok := fmtCache[numElems]
+		if !ok {
+			stringfmt = stringFormat(conf, widths, numElems)
+			fmtCache[numElems] = stringfmt
+		}
+
+		fmt.Fprintf(buf, stringfmt, elems...)
+	}
+
+	// Get the string result
+	result := buf.String()
+
+	// Remove trailing newline without removing leading/trailing space
+	if n := len(result); n > 0 && result[n-1] == '\n' {
+		result = result[:n-1]
+	}
+
+	return result
+}
+
+// SimpleFormat is a convenience function to format text with the defaults.
+func SimpleFormat(lines []string) string {
+	return Format(lines, nil)
+}

--- a/vendor/github.com/ryanuber/columnize/columnize_test.go
+++ b/vendor/github.com/ryanuber/columnize/columnize_test.go
@@ -1,0 +1,340 @@
+package columnize
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	crand "crypto/rand"
+)
+
+func TestListOfStringsInput(t *testing.T) {
+	input := []string{
+		"Column A | Column B | Column C",
+		"x | y | z",
+	}
+
+	config := DefaultConfig()
+	output := Format(input, config)
+
+	expected := "Column A  Column B  Column C\n"
+	expected += "x         y         z"
+
+	if output != expected {
+		t.Fatalf("\nexpected:\n%s\n\ngot:\n%s", expected, output)
+	}
+}
+
+func TestEmptyLinesOutput(t *testing.T) {
+	input := []string{
+		"Column A | Column B | Column C",
+		"",
+		"x | y | z",
+	}
+
+	config := DefaultConfig()
+	output := Format(input, config)
+
+	expected := "Column A  Column B  Column C\n"
+	expected += "\n"
+	expected += "x         y         z"
+
+	if output != expected {
+		t.Fatalf("\nexpected:\n%s\n\ngot:\n%s", expected, output)
+	}
+}
+
+func TestLeadingSpacePreserved(t *testing.T) {
+	input := []string{
+		"| Column B | Column C",
+		"x | y | z",
+	}
+
+	config := DefaultConfig()
+	output := Format(input, config)
+
+	expected := "   Column B  Column C\n"
+	expected += "x  y         z"
+
+	if output != expected {
+		t.Fatalf("\nexpected:\n%s\n\ngot:\n%s", expected, output)
+	}
+}
+
+func TestColumnWidthCalculator(t *testing.T) {
+	input := []string{
+		"Column A | Column B | Column C",
+		"Longer than A | Longer than B | Longer than C",
+		"short | short | short",
+	}
+
+	config := DefaultConfig()
+	output := Format(input, config)
+
+	expected := "Column A       Column B       Column C\n"
+	expected += "Longer than A  Longer than B  Longer than C\n"
+	expected += "short          short          short"
+
+	if output != expected {
+		printableProof := fmt.Sprintf("\nGot:      %+q", output)
+		printableProof += fmt.Sprintf("\nExpected: %+q", expected)
+		t.Fatalf("\n%s", printableProof)
+	}
+}
+
+func TestColumnWidthCalculatorNonASCII(t *testing.T) {
+	input := []string{
+		"Column A | Column B | Column C",
+		"⌘⌘⌘⌘⌘⌘⌘⌘ | Longer than B | Longer than C",
+		"short | short | short",
+	}
+
+	config := DefaultConfig()
+	output := Format(input, config)
+
+	expected := "Column A  Column B       Column C\n"
+	expected += "⌘⌘⌘⌘⌘⌘⌘⌘  Longer than B  Longer than C\n"
+	expected += "short     short          short"
+
+	if output != expected {
+		printableProof := fmt.Sprintf("\nGot:      %+q", output)
+		printableProof += fmt.Sprintf("\nExpected: %+q", expected)
+		t.Fatalf("\n%s", printableProof)
+	}
+}
+
+func BenchmarkColumnWidthCalculator(b *testing.B) {
+	// Generate the input
+	input := []string{
+		"UUID A | UUID B | UUID C | Column D | Column E",
+	}
+
+	format := "%s|%s|%s|%s"
+	short := "short"
+
+	uuid := func() string {
+		buf := make([]byte, 16)
+		if _, err := crand.Read(buf); err != nil {
+			panic(fmt.Errorf("failed to read random bytes: %v", err))
+		}
+
+		return fmt.Sprintf("%08x-%04x-%04x-%04x-%12x",
+			buf[0:4],
+			buf[4:6],
+			buf[6:8],
+			buf[8:10],
+			buf[10:16])
+	}
+
+	for i := 0; i < 1000; i++ {
+		l := fmt.Sprintf(format, uuid()[:8], uuid()[:12], uuid(), short, short)
+		input = append(input, l)
+	}
+
+	config := DefaultConfig()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		Format(input, config)
+	}
+}
+
+func TestVariedInputSpacing(t *testing.T) {
+	input := []string{
+		"Column A       |Column B|    Column C",
+		"x|y|          z",
+	}
+
+	config := DefaultConfig()
+	output := Format(input, config)
+
+	expected := "Column A  Column B  Column C\n"
+	expected += "x         y         z"
+
+	if output != expected {
+		t.Fatalf("\nexpected:\n%s\n\ngot:\n%s", expected, output)
+	}
+}
+
+func TestVariedInputSpacing_NoTrim(t *testing.T) {
+	input := []string{
+		"Column A|Column B|Column C",
+		"x|y|  z",
+	}
+
+	config := DefaultConfig()
+	config.NoTrim = true
+	output := Format(input, config)
+
+	expected := "Column A  Column B  Column C\n"
+	expected += "x         y           z"
+
+	if output != expected {
+		t.Fatalf("\nexpected:\n%s\n\ngot:\n%s", expected, output)
+	}
+}
+
+func TestUnmatchedColumnCounts(t *testing.T) {
+	input := []string{
+		"Column A | Column B | Column C",
+		"Value A | Value B",
+		"Value A | Value B | Value C | Value D",
+	}
+
+	config := DefaultConfig()
+	output := Format(input, config)
+
+	expected := "Column A  Column B  Column C\n"
+	expected += "Value A   Value B\n"
+	expected += "Value A   Value B   Value C   Value D"
+
+	if output != expected {
+		t.Fatalf("\nexpected:\n%s\n\ngot:\n%s", expected, output)
+	}
+}
+
+func TestAlternateDelimiter(t *testing.T) {
+	input := []string{
+		"Column | A % Column | B % Column | C",
+		"Value A % Value B % Value C",
+	}
+
+	config := DefaultConfig()
+	config.Delim = "%"
+	output := Format(input, config)
+
+	expected := "Column | A  Column | B  Column | C\n"
+	expected += "Value A     Value B     Value C"
+
+	if output != expected {
+		t.Fatalf("\nexpected:\n%s\n\ngot:\n%s", expected, output)
+	}
+}
+
+func TestAlternateSpacingString(t *testing.T) {
+	input := []string{
+		"Column A | Column B | Column C",
+		"x | y | z",
+	}
+
+	config := DefaultConfig()
+	config.Glue = "    "
+	output := Format(input, config)
+
+	expected := "Column A    Column B    Column C\n"
+	expected += "x           y           z"
+
+	if output != expected {
+		t.Fatalf("\nexpected:\n%s\n\ngot:\n%s", expected, output)
+	}
+}
+
+func TestSimpleFormat(t *testing.T) {
+	input := []string{
+		"Column A | Column B | Column C",
+		"x | y | z",
+	}
+
+	output := SimpleFormat(input)
+
+	expected := "Column A  Column B  Column C\n"
+	expected += "x         y         z"
+
+	if output != expected {
+		t.Fatalf("\nexpected:\n%s\n\ngot:\n%s", expected, output)
+	}
+}
+
+func TestAlternatePrefixString(t *testing.T) {
+	input := []string{
+		"Column A | Column B | Column C",
+		"x | y | z",
+	}
+
+	config := DefaultConfig()
+	config.Prefix = "  "
+	output := Format(input, config)
+
+	expected := "  Column A  Column B  Column C\n"
+	expected += "  x         y         z"
+
+	if output != expected {
+		t.Fatalf("\nexpected:\n%s\n\ngot:\n%s", expected, output)
+	}
+}
+
+func TestEmptyFieldReplacement(t *testing.T) {
+	input := []string{
+		"Column A | Column B | Column C",
+		"x | | z",
+	}
+
+	config := DefaultConfig()
+	config.Empty = "<none>"
+	output := Format(input, config)
+
+	expected := "Column A  Column B  Column C\n"
+	expected += "x         <none>    z"
+
+	if output != expected {
+		t.Fatalf("\nexpected:\n%s\n\ngot:\n%s", expected, output)
+	}
+}
+
+func TestEmptyConfigValues(t *testing.T) {
+	input := []string{
+		"Column A | Column B | Column C",
+		"x | y | z",
+	}
+
+	config := Config{}
+	output := Format(input, &config)
+
+	expected := "Column A  Column B  Column C\n"
+	expected += "x         y         z"
+
+	if output != expected {
+		t.Fatalf("\nexpected:\n%s\n\ngot:\n%s", expected, output)
+	}
+}
+
+func TestMergeConfig(t *testing.T) {
+	for _, tc := range []struct {
+		desc    string
+		configA *Config
+		configB *Config
+		expect  *Config
+	}{
+		{
+			"merges b over a",
+			&Config{Delim: "a", Glue: "a", Prefix: "a", Empty: "a"},
+			&Config{Delim: "b", Glue: "b", Prefix: "b", Empty: "b"},
+			&Config{Delim: "b", Glue: "b", Prefix: "b", Empty: "b"},
+		},
+		{
+			"merges only non-empty config values",
+			&Config{Delim: "a", Glue: "a", Prefix: "a", Empty: "a"},
+			&Config{Delim: "b", Prefix: "b"},
+			&Config{Delim: "b", Glue: "a", Prefix: "b", Empty: "a"},
+		},
+		{
+			"takes b if a is nil",
+			nil,
+			&Config{Delim: "b", Glue: "b", Prefix: "b", Empty: "b"},
+			&Config{Delim: "b", Glue: "b", Prefix: "b", Empty: "b"},
+		},
+		{
+			"takes a if b is nil",
+			&Config{Delim: "a", Glue: "a", Prefix: "a", Empty: "a"},
+			nil,
+			&Config{Delim: "a", Glue: "a", Prefix: "a", Empty: "a"},
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			m := MergeConfig(tc.configA, tc.configB)
+			if !reflect.DeepEqual(m, tc.expect) {
+				t.Fatalf("\nexpect:\n%#v\n\nactual:\n%#v", tc.expect, m)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR implements `POST /database-auto-upgrade` to perform a rolling update of all server processed with a single `--database.auto-upgrade` start.