### PR TITLE
Added `--starter.host` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changes from version 0.10.4 to master
 
+- Added `--starter.host` option, to bind the HTTP server to a specific network interface instead of the default `0.0.0.0`.
 - Added `POST /data-auto-upgrade` support to perform a rolling upgrade of all servers (with single `--database.auto-upgrade` restart)
 - Renamed mode option `resilientsingle` to `activefailover`. (`resilientsingle` is being supported as alias for a while)
 - Added support for log file rotation for started server components.

--- a/docs/Manual/Programs/Starter/Options.md
+++ b/docs/Manual/Programs/Starter/Options.md
@@ -61,6 +61,17 @@ that `--cluster.agency-size` is set to 1 (see below), the master has to know
 under which address it can be reached from the outside. If you specify
 `localhost` here, then all instances must run on the local machine.
 
+- `--starter.host=addr`
+
+`addr` is the address to which this server binds. (default "0.0.0.0")
+
+Usually there is no need to specify this option.
+Only when you want to bind the starter to specific network device,
+would you set this.
+Note that setting this option to `127.0.0.1` will make this starter
+unreachable for other starters, which is only allowed for
+`single` server deployments or when using `--starter.local`.
+
 - `--docker.image=image`
 
 `image` is the name of a Docker image to run instead of the normal

--- a/main.go
+++ b/main.go
@@ -97,6 +97,7 @@ var (
 	mode                     string
 	dataDir                  string
 	ownAddress               string
+	bindAddress              string
 	masterAddresses          []string
 	verbose                  bool
 	serverThreads            int
@@ -148,6 +149,7 @@ func init() {
 	f.StringVar(&mode, "starter.mode", "cluster", "Set the mode of operation to use (cluster|single|activefailover)")
 	f.BoolVar(&startLocalSlaves, "starter.local", false, "If set, local slaves will be started to create a machine local (test) cluster")
 	f.StringVar(&ownAddress, "starter.address", "", "address under which this server is reachable, needed for running in docker or in single mode")
+	f.StringVar(&bindAddress, "starter.host", "0.0.0.0", "address used to bind the starter to")
 	f.StringVar(&id, "starter.id", "", "Unique identifier of this peer")
 	f.IntVar(&masterPort, "starter.port", service.DefaultMasterPort, "Port to listen on for other arangodb's to join")
 	f.BoolVar(&allPortOffsetsUnique, "starter.unique-port-offsets", false, "If set, all peers will get a unique port offset. If false (default) only portOffset+peerAddress pairs will be unique.")
@@ -650,6 +652,7 @@ func mustPrepareService(generateAutoKeyFile bool) (*service.Service, service.Boo
 		RrPath:                  rrPath,
 		DataDir:                 dataDir,
 		OwnAddress:              ownAddress,
+		BindAddress:             bindAddress,
 		MasterAddresses:         masterAddresses,
 		Verbose:                 verbose,
 		ServerThreads:           serverThreads,

--- a/service/service.go
+++ b/service/service.go
@@ -55,6 +55,7 @@ type Config struct {
 	RrPath               string
 	DataDir              string
 	OwnAddress           string // IP address of used to reach this process
+	BindAddress          string // IP address the HTTP server binds to (typically '0.0.0.0')
 	MasterAddresses      []string
 	Verbose              bool
 	ServerThreads        int  // If set to something other than 0, this will be added to the commandline of each server with `--server.threads`...
@@ -909,7 +910,7 @@ func (s *Service) createHTTPServer(config Config) (srv *httpServer, containerPor
 	if err != nil {
 		return nil, 0, "", "", maskAny(err)
 	}
-	containerAddr = fmt.Sprintf("0.0.0.0:%d", containerPort)
+	containerAddr = net.JoinHostPort(config.BindAddress, strconv.Itoa(containerPort))
 	hostAddr = net.JoinHostPort(config.OwnAddress, strconv.Itoa(hostPort))
 
 	// Create HTTP server


### PR DESCRIPTION
Added option to customize the bind address of the starter.
This is typically used to bind only to a specific network device.

fixes #139