### PR TITLE
Do not port check on any device when starter.host is given

### DIFF
--- a/service/bootstrap_master.go
+++ b/service/bootstrap_master.go
@@ -41,7 +41,7 @@ func (s *Service) bootstrapMaster(ctx context.Context, runner Runner, config Con
 	if err != nil {
 		s.log.Fatalf("Cannot find HTTP server info: %#v", err)
 	}
-	if !WaitUntilPortAvailable(containerHTTPPort, time.Second*5) {
+	if !WaitUntilPortAvailable(config.BindAddress, containerHTTPPort, time.Second*5) {
 		s.log.Fatalf("Port %d is already in use", containerHTTPPort)
 	}
 

--- a/service/bootstrap_slave.go
+++ b/service/bootstrap_slave.go
@@ -113,7 +113,7 @@ func (s *Service) bootstrapSlave(peerAddress string, runner Runner, config Confi
 	if err != nil {
 		s.log.Fatalf("Cannot find HTTP server info: %#v", err)
 	}
-	if !WaitUntilPortAvailable(containerHTTPPort, time.Second*5) {
+	if !WaitUntilPortAvailable(config.BindAddress, containerHTTPPort, time.Second*5) {
 		s.log.Fatalf("Port %d is already in use", containerHTTPPort)
 	}
 

--- a/service/port_check.go
+++ b/service/port_check.go
@@ -23,14 +23,14 @@
 package service
 
 import (
-	"fmt"
 	"net"
+	"strconv"
 	"time"
 )
 
 // IsPortOpen checks if a TCP port is free to listen on.
-func IsPortOpen(port int) bool {
-	l, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+func IsPortOpen(host string, port int) bool {
+	l, err := net.Listen("tcp", net.JoinHostPort(host, strconv.Itoa(port)))
 	if err != nil {
 		return false
 	}
@@ -41,10 +41,10 @@ func IsPortOpen(port int) bool {
 // WaitUntilPortAvailable waits until a TCP port is free to listen on
 // or a timeout occurs.
 // Returns true when port is free to listen on.
-func WaitUntilPortAvailable(port int, timeout time.Duration) bool {
+func WaitUntilPortAvailable(host string, port int, timeout time.Duration) bool {
 	start := time.Now()
 	for {
-		if IsPortOpen(port) {
+		if IsPortOpen(host, port) {
 			return true
 		}
 		if time.Since(start) >= timeout {

--- a/service/runtime_server_manager.go
+++ b/service/runtime_server_manager.go
@@ -131,7 +131,7 @@ func startServer(ctx context.Context, log *logging.Logger, runtimeContext runtim
 	}
 
 	// Check availability of port
-	if !WaitUntilPortAvailable(myPort, time.Second*3) {
+	if !WaitUntilPortAvailable("", myPort, time.Second*3) {
 		return nil, true, maskAny(fmt.Errorf("Cannot start %s, because port %d is already in use", serverType, myPort))
 	}
 


### PR DESCRIPTION
When `--starter.host` is given, the HTTP server of the starter is bound to that address.
This PR ensures that also the port-is-free check is done on that address and not the `any` address.