### PR TITLE
Cancel ExpectTimeout on remaining SubProcesses when a good result has been received

### DIFF
--- a/test/gexpect.go
+++ b/test/gexpect.go
@@ -24,6 +24,7 @@ package test
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -153,7 +154,8 @@ func (sp *SubProcess) Wait() error {
 // ExpectTimeout waits for the output of the process to match the given expression, or until a timeout occurs.
 // If a match on the given expression is found, the process output is discard until the end of the match and
 // nil is returned, otherwise a timeout error is returned.
-func (sp *SubProcess) ExpectTimeout(timeout time.Duration, re *regexp.Regexp, id string) error {
+// If the given context is cancelled, nil is returned.
+func (sp *SubProcess) ExpectTimeout(ctx context.Context, timeout time.Duration, re *regexp.Regexp, id string) error {
 	found := make(chan struct{})
 
 	sp.mutex.Lock()
@@ -163,6 +165,8 @@ func (sp *SubProcess) ExpectTimeout(timeout time.Duration, re *regexp.Regexp, id
 	sp.matchExpressions()
 
 	select {
+	case <-ctx.Done():
+		return nil
 	case <-time.After(timeout):
 		// Return timeout error
 		var output []byte

--- a/test/passthrough_test.go
+++ b/test/passthrough_test.go
@@ -23,6 +23,7 @@
 package test
 
 import (
+	"context"
 	"os"
 	"regexp"
 	"testing"
@@ -39,7 +40,8 @@ func TestPassthroughConflict(t *testing.T) {
 	defer child.Close()
 
 	expr := regexp.MustCompile("is essential to the starters behavior and cannot be overwritten")
-	if err := child.ExpectTimeout(time.Second*15, expr, "starter-passthrough"); err != nil {
+	ctx := context.Background()
+	if err := child.ExpectTimeout(ctx, time.Second*15, expr, "starter-passthrough"); err != nil {
 		t.Errorf("Expected errors message, got %#v", err)
 	}
 }


### PR DESCRIPTION
Tests for active-failover did PASS, but showed nasty warnings about timeouts.

Of the 3 active-failover starters, only 1 outputs the line showing "Active failover now available..."
the test expectation for the other 2 starters remained active and after a timeout of 2min dumped
its content in the test output.

So as soon as one of the starters showed the expected line, the test was a PASS and terminated.
But the remaining SubProcess kept waiting for the expected line to appear (which will never happen)
and therefor timeout after 2min, resulting is dumping its output in the middle of a later test that was now active.

This PR prevents this mess, by canceling the remaining SubProcesses as soon as the correct ready state has been reached.