### PR TITLE
Fix command

### DIFF
--- a/docs/Manual/Security/Starter/README.md
+++ b/docs/Manual/Security/Starter/README.md
@@ -19,8 +19,8 @@ _--javascript.execute-string_ option of the _arangosh_ binary, e.g.:
 
 ```bash
 arangosh --server.endpoint your-server-endpoint \
-    --server.password ""
-    --javascript.execute-string 'require("org/arangodb/users").update("root", "mypwd");
+    --server.password "" \
+    --javascript.execute-string 'require("org/arangodb/users").update("root", "mypwd");'
 ```
 
 where "mypwd" is the new password you want to set.


### PR DESCRIPTION
Added a` \` to 
--server.password ""
and added  `'` after `;` to:
--javascript.execute-string 'require("org/arangodb/users").update("root", "mypwd");

