### PR TITLE
Prevent storing an "updated" ClusterConfig when it has not changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Changes from version 0.13.3 to master
 
+- Starter cluster configuration no longer written to `setup.json` when
+  it has not changed.
+
 ## Changes from version 0.13.2 to 0.13.3
 
 - Fixed a bug in the RECOVERY procedure which was declined if a new

--- a/service/service.go
+++ b/service/service.go
@@ -33,6 +33,7 @@ import (
 	"net"
 	"net/http"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -1043,9 +1044,14 @@ func (s *Service) UpdateClusterConfig(newConfig ClusterConfig) {
 		return
 	}
 
-	// TODO only update when changed
-	s.myPeers = newConfig
-	s.saveSetup()
+	// Only update when changed
+	if !reflect.DeepEqual(s.myPeers, newConfig) {
+		s.myPeers = newConfig
+		s.saveSetup()
+		s.log.Debug().Msg("Updated cluster config")
+	} else {
+		s.log.Debug().Msg("Updating cluster config is not needed")
+	}
 }
 
 // MasterChangedCallback interrupts the runtime cluster manager


### PR DESCRIPTION
This PR prevents writing `setup.json` if there is no change.