### PR TITLE
Fixed upgrade for active failover.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ArangoDB Starter Changelog
 
+## Changes from 0.14.12 to 0.14.13
+
+- Fixed upgrade for active failover when there are nodes without single server.
+
 ## Changes from 0.14.11 to 0.14.12
 
 - Fixed wrong error message.

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,6 @@ endif
 
 ifdef TRAVIS
 	IP := $(shell hostname -I | cut -d ' ' -f 1)
-	echo Using IP=$(IP)
 endif
 
 TEST_TIMEOUT := 25m

--- a/service/cluster_config.go
+++ b/service/cluster_config.go
@@ -258,6 +258,11 @@ func (p ClusterConfig) GetAllSingleEndpoints() ([]string, error) {
 	return result, nil
 }
 
+// GetResilientSingleEndpoints creates a list of URL's for all resilient single servers.
+func (p ClusterConfig) GetResilientSingleEndpoints() ([]string, error) {
+	return p.GetSingleEndpoints(false)
+}
+
 // GetSingleEndpoints creates a list of URL's for all single servers.
 func (p ClusterConfig) GetSingleEndpoints(all bool) ([]string, error) {
 	// Build endpoint list

--- a/service/upgrade_manager.go
+++ b/service/upgrade_manager.go
@@ -723,7 +723,7 @@ func (m *upgradeManager) fetchRunningDatabaseVersions(ctx context.Context) ([]dr
 		}
 	}
 	if mode.IsSingleMode() || mode.IsActiveFailoverMode() {
-		if err := collect(config.GetAllSingleEndpoints, ConnectionTypeDatabase); err != nil {
+		if err := collect(config.GetResilientSingleEndpoints, ConnectionTypeDatabase); err != nil {
 			return nil, maskAny(err)
 		}
 	}


### PR DESCRIPTION
When doing an upgrade and there is a node which does not have an single server, the starter tried to upgrade the single server on that node and failed.