### PR TITLE
Leave Cluster 404

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -467,7 +467,7 @@ func (s *Service) sendMasterLeaveCluster() error {
 	if err != nil {
 		return maskAny(err)
 	}
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNotFound {
 		return maskAny(client.ParseResponseError(resp, nil))
 	}
 


### PR DESCRIPTION
When doing `sendMasterLeaveCluster` ignore a 404 to become idempotent.