### PR TITLE
Fix wait loop for agency job completion

### DIFF
--- a/service/job.go
+++ b/service/job.go
@@ -102,7 +102,6 @@ func WaitForFinishedJob(progress actions.Progressor, ctx context.Context, jobID 
 		case <-time.After(time.Second * 2): // TODO memory leak
 			progress.Progress(fmt.Sprintf("Job %s of type %s for server %s in state %s: %s", job.JobID, job.Type, job.Server, string(job.state), job.Reason))
 
-			break
 		}
 	}
 }


### PR DESCRIPTION
I found that the starter does not actually wait for the completion of
agency jobs for more than 2s. This PR should address the problem, since
it removes a bad `break` statement.
