### PR TITLE
added user, exp, and allowed_paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [master](https://github.com/arangodb-helper/arangodb/tree/master) (N/A)
 - Allow to pass environment variables to processes and standardize argument pass (--envs.<group>.<ENV>=<VALUE> and --args.<group>.<ARG>=<VALUE>)
+- Extend JWT Generator functionality by additional fields
 
 # ArangoDB Starter Changelog Before 0.15.0
 

--- a/auth.go
+++ b/auth.go
@@ -51,6 +51,8 @@ var (
 	authOptions struct {
 		jwtSecretFile string
 		user          string
+		paths         []string
+                exp           int64
 	}
 )
 
@@ -62,6 +64,8 @@ func init() {
 	pf := cmdAuth.PersistentFlags()
 	pf.StringVar(&authOptions.jwtSecretFile, "auth.jwt-secret", "", "name of a plain text file containing a JWT secret used for server authentication")
 	pf.StringVar(&authOptions.user, "auth.user", "", "name of a user to authenticate as. If empty, 'super-user' authentication is used")
+	pf.StringSliceVar(&authOptions.paths, "auth.paths", nil, "a list of allowed pathes. The path must not include the '_db/DBNAME' prefix.")
+	pf.Int64Var(&authOptions.exp, "auth.exp", 0, "an expiry date in seconds since epoche")
 }
 
 // mustAuthCreateJWTToken creates a the JWT token based on authentication options.
@@ -77,7 +81,7 @@ func mustAuthCreateJWTToken() string {
 		log.Fatal().Err(err).Msgf("Failed to read JWT secret file '%s'", authOptions.jwtSecretFile)
 	}
 	jwtSecret := strings.TrimSpace(string(content))
-	token, err := service.CreateJwtToken(jwtSecret, authOptions.user)
+	token, err := service.CreateJwtToken(jwtSecret, authOptions.user, "", authOptions.paths, authOptions.exp)
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to create JWT token")
 	}

--- a/auth_test.go
+++ b/auth_test.go
@@ -1,0 +1,47 @@
+//
+// DISCLAIMER
+//
+// Copyright 2021 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+// Author Adam Janikowski
+//
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func parseDuration(t *testing.T, in, out string) {
+	t.Run(in, func(t *testing.T) {
+		v, err := durationParser(in, "s")
+		require.NoError(t, err)
+
+		s := v.String()
+
+		require.Equal(t, out, s)
+	})
+}
+
+func Test_Auth_DurationTest(t *testing.T) {
+	parseDuration(t, "5", "5s")
+	parseDuration(t, "5s", "5s")
+	parseDuration(t, "5m", "5m0s")
+	parseDuration(t, "5h", "5h0m0s")
+}

--- a/service/authentication.go
+++ b/service/authentication.go
@@ -24,6 +24,7 @@ package service
 
 import (
 	"net/http"
+	"time"
 
 	jwt "github.com/dgrijalva/jwt-go"
 )
@@ -35,12 +36,12 @@ const (
 
 // CreateJwtToken calculates a JWT authorization token based on the given secret.
 // If the secret is empty, an empty token is returned.
-func CreateJwtToken(jwtSecret, user string, serverId string, paths []string, exp int64) (string, error) {
+func CreateJwtToken(jwtSecret, user string, serverId string, paths []string, exp time.Duration) (string, error) {
 	if jwtSecret == "" {
 		return "", nil
 	}
-        if serverId == "" {
-	        serverId = "foo"
+	if serverId == "" {
+		serverId = "foo"
 	}
 
 	// Create a new token object, specifying signing method and the claims
@@ -56,7 +57,7 @@ func CreateJwtToken(jwtSecret, user string, serverId string, paths []string, exp
 		claims["allowed_paths"] = paths
 	}
 	if exp > 0 {
-		claims["exp"] = exp
+		claims["exp"] = time.Now().UTC().Add(exp).Unix()
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 


### PR DESCRIPTION
This add two flags the the command "create jwt":

--auth.user: to specify a user
--auth.paths: to specify allowed paths
--auth.exp: to specify an expiry
