### PR TITLE
Patch typo in error msg - process_wrapper.go

### DIFF
--- a/service/process_wrapper.go
+++ b/service/process_wrapper.go
@@ -207,7 +207,7 @@ func (p *processWrapper) run(startedCh chan<- struct{}) {
 							} else {
 								ip := p.myPeer.Address
 								p.s.logMutex.Lock()
-								logProcess.Info().Msgf("Your syncmaster can now available at `https://%s:%d`", ip, hostPort)
+								logProcess.Info().Msgf("Your syncmaster is now available at `https://%s:%d`", ip, hostPort)
 								p.s.logMutex.Unlock()
 							}
 						}


### PR DESCRIPTION
When starting ArangoDB starter, the log prints:
`Your syncmaster can now available at `https://<node>:<port>` component=arangodb pid=<pid> type=syncmaster`

This should be printing:
`Your syncmaster is now available at `https://<node>:<port>` component=arangodb pid=<pid> type=syncmaster`