### PR TITLE
Special upgrade without ResignLeadership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [master](https://github.com/arangodb-helper/arangodb/tree/master) (N/A)
 - Allow to pass environment variables to processes and standardize argument pass (--envs.<group>.<ENV>=<VALUE> and --args.<group>.<ARG>=<VALUE>)
 - Extend JWT Generator functionality by additional fields
+- Do not run ResignLeadership when upgrading from <= 3.6.14 or 
+  3.7 with <= 3.7.13.
 
 # ArangoDB Starter Changelog Before 0.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Allow to pass environment variables to processes and standardize argument pass (--envs.<group>.<ENV>=<VALUE> and --args.<group>.<ARG>=<VALUE>)
 - Extend JWT Generator functionality by additional fields
 - Do not run ResignLeadership when upgrading from <= 3.6.14 or 
-  3.7 with <= 3.7.13.
+  3.7 with <= 3.7.12.
 
 # ArangoDB Starter Changelog Before 0.15.0
 

--- a/pkg/definitions/server_type.go
+++ b/pkg/definitions/server_type.go
@@ -31,14 +31,15 @@ import (
 type ServerType string
 
 const (
-	ServerTypeUnknown         = "unknown"
-	ServerTypeCoordinator     = "coordinator"
-	ServerTypeDBServer        = "dbserver"
-	ServerTypeAgent           = "agent"
-	ServerTypeSingle          = "single"
-	ServerTypeResilientSingle = "resilientsingle"
-	ServerTypeSyncMaster      = "syncmaster"
-	ServerTypeSyncWorker      = "syncworker"
+	ServerTypeUnknown          = "unknown"
+	ServerTypeCoordinator      = "coordinator"
+	ServerTypeDBServer         = "dbserver"
+	ServerTypeDBServerNoResign = "dbserver_noresign"
+	ServerTypeAgent            = "agent"
+	ServerTypeSingle           = "single"
+	ServerTypeResilientSingle  = "resilientsingle"
+	ServerTypeSyncMaster       = "syncmaster"
+	ServerTypeSyncWorker       = "syncworker"
 )
 
 // String returns a string representation of the given ServerType.
@@ -51,7 +52,7 @@ func (s ServerType) PortOffset() int {
 	switch s {
 	case ServerTypeCoordinator, ServerTypeSingle, ServerTypeResilientSingle:
 		return PortOffsetCoordinator
-	case ServerTypeDBServer:
+	case ServerTypeDBServer, ServerTypeDBServerNoResign:
 		return PortOffsetDBServer
 	case ServerTypeAgent:
 		return PortOffsetAgent
@@ -93,7 +94,7 @@ func (s ServerType) ExpectedServerRole() (string, string) {
 		return "SINGLE", ""
 	case ServerTypeResilientSingle:
 		return "SINGLE", "resilient"
-	case ServerTypeDBServer:
+	case ServerTypeDBServer, ServerTypeDBServerNoResign:
 		return "PRIMARY", ""
 	case ServerTypeAgent:
 		return "AGENT", ""
@@ -110,6 +111,8 @@ func (s ServerType) GetName() string {
 	case ServerTypeAgent:
 		return "agent"
 	case ServerTypeDBServer:
+		return "dbserver"
+  case ServerTypeDBServerNoResign:
 		return "dbserver"
 	case ServerTypeCoordinator:
 		return "coordinator"
@@ -128,6 +131,7 @@ func AllServerTypes() []ServerType {
 	return []ServerType{
 		ServerTypeCoordinator,
 		ServerTypeDBServer,
+    ServerTypeDBServerNoResign,
 		ServerTypeAgent,
 		ServerTypeSingle,
 		ServerTypeResilientSingle,

--- a/pkg/definitions/server_type.go
+++ b/pkg/definitions/server_type.go
@@ -112,7 +112,7 @@ func (s ServerType) GetName() string {
 		return "agent"
 	case ServerTypeDBServer:
 		return "dbserver"
-  case ServerTypeDBServerNoResign:
+	case ServerTypeDBServerNoResign:
 		return "dbserver"
 	case ServerTypeCoordinator:
 		return "coordinator"
@@ -131,7 +131,7 @@ func AllServerTypes() []ServerType {
 	return []ServerType{
 		ServerTypeCoordinator,
 		ServerTypeDBServer,
-    ServerTypeDBServerNoResign,
+		ServerTypeDBServerNoResign,
 		ServerTypeAgent,
 		ServerTypeSingle,
 		ServerTypeResilientSingle,

--- a/service/runtime_server_manager.go
+++ b/service/runtime_server_manager.go
@@ -513,6 +513,8 @@ func (s *runtimeServerManager) RestartServer(log zerolog.Logger, serverType defi
 		p = s.agentProc.Process()
 	case definitions.ServerTypeDBServer:
 		p = s.dbserverProc.Process()
+	case definitions.ServerTypeDBServerNoResign:
+		p = s.dbserverProc.Process()
 	case definitions.ServerTypeCoordinator:
 		p = s.coordinatorProc.Process()
 	case definitions.ServerTypeSingle, definitions.ServerTypeResilientSingle:

--- a/test/process_cluster_resign_leadership_test.go
+++ b/test/process_cluster_resign_leadership_test.go
@@ -82,6 +82,8 @@ func TestProcessClusterResignLeadership(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
+	WaitUntilServiceReadyAPI(t, coordinatorClient, ServiceReadyCheckVersion()).ExecuteT(t, 15*time.Second, 500*time.Millisecond)
+
 	if version, err := coordinatorClient.Version(context.Background()); err != nil {
 		t.Fatal(err.Error())
 	} else {
@@ -94,10 +96,7 @@ func TestProcessClusterResignLeadership(t *testing.T) {
 	databaseName := "_system"
 	collectionName := "test"
 
-	WaitUntilServiceReadyAPI(t, coordinatorClient, func(t *testing.T, ctx context.Context, c driver.Client) error {
-		_, err := coordinatorClient.Database(context.Background(), databaseName)
-		return err
-	}).ExecuteT(t, 15*time.Second, 500*time.Millisecond)
+	WaitUntilServiceReadyAPI(t, coordinatorClient, ServiceReadyCheckDatabase(databaseName)).ExecuteT(t, 15*time.Second, 500*time.Millisecond)
 
 	database, err := coordinatorClient.Database(context.Background(), databaseName)
 	if err != nil {

--- a/test/process_cluster_resign_leadership_test.go
+++ b/test/process_cluster_resign_leadership_test.go
@@ -30,6 +30,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/arangodb-helper/arangodb/service"
+
 	"github.com/arangodb-helper/arangodb/client"
 	"github.com/arangodb/go-driver"
 	"github.com/pkg/errors"
@@ -78,6 +80,14 @@ func TestProcessClusterResignLeadership(t *testing.T) {
 	coordinatorClient, err := CreateClient(t, starterEndpointForCoordinator, client.ServerTypeCoordinator, auth)
 	if err != nil {
 		t.Fatal(err.Error())
+	}
+
+	if version, err := coordinatorClient.Version(context.Background()); err != nil {
+		t.Fatal(err.Error())
+	} else {
+		if service.IsSpecialUpgradeFrom3614(version.Version) {
+			t.Skipf("ResignLeadership wont work in case when Maintenance is enabled")
+		}
 	}
 
 	databaseName := "_system"

--- a/test/process_cluster_resign_leadership_test.go
+++ b/test/process_cluster_resign_leadership_test.go
@@ -85,6 +85,7 @@ func TestProcessClusterResignLeadership(t *testing.T) {
 	if version, err := coordinatorClient.Version(context.Background()); err != nil {
 		t.Fatal(err.Error())
 	} else {
+		t.Log("Found version: ", version.Version)
 		if service.IsSpecialUpgradeFrom3614(version.Version) {
 			t.Skipf("ResignLeadership wont work in case when Maintenance is enabled")
 		}

--- a/test/util.go
+++ b/test/util.go
@@ -265,6 +265,22 @@ func WaitUntilServiceReady(t *testing.T, c driver.Client, checkFunc ServiceReady
 	}
 }
 
+// ServiceReadyCheckVersion checks if version can be fetched
+func ServiceReadyCheckVersion() ServiceReadyCheckFunc {
+	return func(t *testing.T, ctx context.Context, c driver.Client) error {
+		_, err := c.Version(ctx)
+		return err
+	}
+}
+
+// ServiceReadyCheckDatabase checks if database info can be fetched
+func ServiceReadyCheckDatabase(databaseName string) ServiceReadyCheckFunc {
+	return func(t *testing.T, ctx context.Context, c driver.Client) error {
+		_, err := c.Database(ctx, databaseName)
+		return err
+	}
+}
+
 func WaitForHttpPortClosed(log Logger, throttle Throttle, url string) TimeoutFunc {
 	return func() error {
 		_, err := http.Get(url)


### PR DESCRIPTION
Do not run ResignLeadership when coming from certain versions.

Details:
  - <= 3.6.14 or
  - 3.7 and <= 3.7.12
