### PR TITLE
GT-99 Add support for ArangoD exit codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Return correct exit code when wrong CLI params supplied
 - Upgrade Go version to 1.17.8
 - Cleanup Travis config and make it use the list of actual ArangoD versions
+- Add support for ArangoD exit codes. Do not try to restart instance if exit code is unrecoverable
 
 ## [0.15.4](https://github.com/arangodb-helper/arangodb/tree/0.15.4) (2022-03-22)
 - Use github.com/golang-jwt/jwt

--- a/Makefile
+++ b/Makefile
@@ -236,6 +236,10 @@ tools:
 	@echo ">> Fetching github release"
 	@GOBIN=$(GOPATH)/bin go install github.com/aktau/github-release@v0.8.1
 
+.PHONY: generate
+generate:
+	go generate
+
 .PHONY: license
 license:
 	@echo ">> Verify license of files"

--- a/internal/generate-exit-codes/main.go
+++ b/internal/generate-exit-codes/main.go
@@ -1,0 +1,191 @@
+//
+// DISCLAIMER
+//
+// Copyright 2017-2022 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+
+package main
+
+import (
+	"bytes"
+	"encoding/csv"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	exitCodesDat = "https://raw.githubusercontent.com/arangodb/arangodb/main/lib/Basics/exitcodes.dat"
+)
+
+type exitCode struct {
+	code        int
+	reason      string
+	description string
+}
+
+func fatal(args ...interface{}) {
+	fmt.Print(args...)
+	os.Exit(1)
+}
+
+func main() {
+	root, err := os.Getwd()
+	if err != nil {
+		fatal(err)
+		return
+	}
+
+	dat, err := downloadArangodExitCodesDat()
+	if err != nil {
+		fatal(err)
+		return
+	}
+
+	exitCodes, err := parseArangoDExitCodes(string(dat))
+	if err != nil {
+		fatal(err)
+		return
+	}
+
+	err = generateExitCodesGoSource(exitCodes, root, err)
+	if err != nil {
+		fatal(err)
+		return
+	}
+
+	fmt.Printf("ArangoD exit codes consts generated. Total %d codes found\n", len(exitCodes))
+}
+
+func generateExitCodesGoSource(exitCodes map[string]exitCode, root string, err error) error {
+	header, err := getLicenseHeader(root)
+	if err != nil {
+		return err
+	}
+
+	buf := bytes.Buffer{}
+	buf.WriteString(header)
+	buf.WriteString(`
+// Code generated automatically. DO NOT EDIT.
+
+package definitions
+
+const (
+`)
+	for name, code := range exitCodes {
+		buf.WriteString(fmt.Sprintf("	// %s\n", name))
+		buf.WriteString(fmt.Sprintf(`	%s = %d // %s
+`, getConstName(name), code.code, code.description))
+	}
+	buf.WriteString(")\n\n")
+
+	buf.WriteString("var arangoDExitReason = map[int]string{\n")
+	for name, code := range exitCodes {
+		buf.WriteString(fmt.Sprintf("	// %s\n", name))
+		buf.WriteString(fmt.Sprintf("	%s: \"%s\",\n", getConstName(name), code.reason))
+	}
+	buf.WriteString("}\n")
+
+	resultFilePath := fmt.Sprintf("%s/pkg/definitions/exitcodes_generated.go", root)
+	err = ioutil.WriteFile(resultFilePath, buf.Bytes(), 0600)
+	return err
+}
+
+func getConstName(n string) string {
+	prev := '_'
+	// convert SOME_CONST_NAME to SomeConstName:
+	dropUnderscoreAndStringify := func(r rune) rune {
+		if prev == '_' {
+			prev = r
+			return unicode.ToTitle(r)
+		}
+		prev = r
+		if r == '_' {
+			return -1
+		}
+		return r
+	}
+	return "ArangoD" + strings.Map(dropUnderscoreAndStringify, strings.ToLower(n))
+}
+
+func downloadArangodExitCodesDat() ([]byte, error) {
+	resp, err := http.Get(exitCodesDat)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	return ioutil.ReadAll(resp.Body)
+}
+
+func parseArangoDExitCodes(dat string) (map[string]exitCode, error) {
+	// omit comments
+	lines := strings.Split(dat, "\n")
+	dat = ""
+	for _, line := range lines {
+		parts := strings.Split(line, "#")
+		if len(parts[0]) > 0 {
+			dat += parts[0] + "\n"
+		}
+	}
+
+	b := bytes.NewBufferString(dat)
+	csvReader := csv.NewReader(b)
+	records, err := csvReader.ReadAll()
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[string]exitCode, len(records))
+	for _, r := range records {
+		if len(r) < 4 {
+			return nil, fmt.Errorf("expected at least 4 fields, got: %+v", r)
+		}
+		code, err := strconv.Atoi(r[1])
+		if err != nil {
+			return nil, errors.Wrapf(err, "while converting %s", r[1])
+		}
+		result[r[0]] = exitCode{
+			code:        code,
+			reason:      r[2],
+			description: r[3],
+		}
+	}
+	return result, nil
+}
+
+func getLicenseHeader(root string) (string, error) {
+	headerBoilerplate := fmt.Sprintf("%s/LICENSE.BOILERPLATE", root)
+	b, err := ioutil.ReadFile(headerBoilerplate)
+	if err != nil {
+		return "", err
+	}
+	result := ""
+	for _, line := range strings.Split(string(b), "\n") {
+		if len(line) > 0 {
+			result += "// " + line + "\n"
+		} else {
+			result += "//\n"
+		}
+	}
+	return result, nil
+}

--- a/main.go
+++ b/main.go
@@ -55,6 +55,8 @@ import (
 	"github.com/arangodb-helper/arangodb/service/options"
 )
 
+//go:generate go run internal/generate-exit-codes/main.go
+
 // Configuration data with defaults:
 
 const (

--- a/pkg/definitions/exitcodes.go
+++ b/pkg/definitions/exitcodes.go
@@ -1,0 +1,46 @@
+//
+// DISCLAIMER
+//
+// Copyright 2017-2022 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+
+package definitions
+
+func GetExitCodeReason(code int) string {
+	if r, ok := arangoDExitReason[code]; ok {
+		return r
+	}
+	return "reason unknown"
+}
+
+// ExitCodeIsRecoverable returns true if provided code indicates that restarting ArangoD process with exact same config won't help
+func ExitCodeIsRecoverable(pType ProcessType, code int) bool {
+	if pType == ProcessTypeArangoSync {
+		return true
+	}
+	switch code {
+	case ArangoDExitBinaryNotFound,
+		ArangoDExitConfigNotFound,
+		ArangoDExitIcuInitializationFailed,
+		ArangoDExitTzdataInitializationFailed,
+		ArangoDExitResourcesTooLow,
+		ArangoDExitDbNotEmpty,
+		ArangoDExitUnsupportedStorageEngine:
+		return false
+	}
+	return true
+}

--- a/pkg/definitions/exitcodes_generated.go
+++ b/pkg/definitions/exitcodes_generated.go
@@ -1,0 +1,102 @@
+//
+// DISCLAIMER
+//
+// Copyright 2017-2022 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+//
+
+// Code generated automatically. DO NOT EDIT.
+
+package definitions
+
+const (
+	// EXIT_CONFIG_NOT_FOUND
+	ArangoDExitConfigNotFound = 6 // Will be returned if no valid configuration was found
+	// EXIT_UPGRADE_FAILED
+	ArangoDExitUpgradeFailed = 10 // Will be returned when the database upgrade failed
+	// EXIT_COULD_NOT_LOCK
+	ArangoDExitCouldNotLock = 22 // Will be returned if another ArangoDB process is running, or the state can not be cleared
+	// EXIT_ICU_INITIALIZATION_FAILED
+	ArangoDExitIcuInitializationFailed = 26 // Will be returned if icudtl.dat is not found, of the wrong version or invalid. Check for an incorrectly set ICU_DATA environment variable
+	// EXIT_RESOURCES_TOO_LOW
+	ArangoDExitResourcesTooLow = 28 // Will be returned if i.e. ulimit is too restrictive
+	// EXIT_BINARY_NOT_FOUND
+	ArangoDExitBinaryNotFound = 5 // Will be returned if a referenced binary was not found
+	// EXIT_COULD_NOT_BIND_PORT
+	ArangoDExitCouldNotBindPort = 21 // Will be returned when the configured tcp endpoint is already occupied by another process
+	// EXIT_RECOVERY
+	ArangoDExitRecovery = 23 // Will be returned if the automatic database startup recovery fails
+	// EXIT_TZDATA_INITIALIZATION_FAILED
+	ArangoDExitTzdataInitializationFailed = 27 // Will be returned if tzdata is not found
+	// EXIT_SUCCESS
+	ArangoDExitSuccess = 0 // No error has occurred.
+	// EXIT_CODE_RESOLVING_FAILED
+	ArangoDExitCodeResolvingFailed = 2 // unspecified exit code
+	// EXIT_UPGRADE_REQUIRED
+	ArangoDExitUpgradeRequired = 11 // Will be returned when a database upgrade is required
+	// EXIT_DOWNGRADE_REQUIRED
+	ArangoDExitDowngradeRequired = 12 // Will be returned when a database upgrade is required
+	// EXIT_UNSUPPORTED_STORAGE_ENGINE
+	ArangoDExitUnsupportedStorageEngine = 25 // Will be returned when trying to start with an unsupported storage engine
+	// EXIT_FAILED
+	ArangoDExitFailed = 1 // Will be returned when a general error occurred.
+	// EXIT_VERSION_CHECK_FAILED
+	ArangoDExitVersionCheckFailed = 13 // Will be returned when there is a version mismatch
+	// EXIT_ALREADY_RUNNING
+	ArangoDExitAlreadyRunning = 20 // Will be returned when arangod is already running according to PID-file
+	// EXIT_DB_NOT_EMPTY
+	ArangoDExitDbNotEmpty = 24 // Will be returned when commanding to initialize a non empty directory as database
+)
+
+var arangoDExitReason = map[int]string{
+	// EXIT_UPGRADE_REQUIRED
+	ArangoDExitUpgradeRequired: "db upgrade required",
+	// EXIT_DOWNGRADE_REQUIRED
+	ArangoDExitDowngradeRequired: "db downgrade required",
+	// EXIT_SUCCESS
+	ArangoDExitSuccess: "success",
+	// EXIT_CODE_RESOLVING_FAILED
+	ArangoDExitCodeResolvingFailed: "exit code resolving failed",
+	// EXIT_ALREADY_RUNNING
+	ArangoDExitAlreadyRunning: "already running",
+	// EXIT_DB_NOT_EMPTY
+	ArangoDExitDbNotEmpty: "database not empty",
+	// EXIT_UNSUPPORTED_STORAGE_ENGINE
+	ArangoDExitUnsupportedStorageEngine: "unsupported storage engine",
+	// EXIT_FAILED
+	ArangoDExitFailed: "exit with error",
+	// EXIT_VERSION_CHECK_FAILED
+	ArangoDExitVersionCheckFailed: "version check failed",
+	// EXIT_COULD_NOT_LOCK
+	ArangoDExitCouldNotLock: "could not lock - another process could be running",
+	// EXIT_ICU_INITIALIZATION_FAILED
+	ArangoDExitIcuInitializationFailed: "failed to initialize ICU library",
+	// EXIT_CONFIG_NOT_FOUND
+	ArangoDExitConfigNotFound: "config not found",
+	// EXIT_UPGRADE_FAILED
+	ArangoDExitUpgradeFailed: "upgrade failed",
+	// EXIT_RECOVERY
+	ArangoDExitRecovery: "recovery failed",
+	// EXIT_TZDATA_INITIALIZATION_FAILED
+	ArangoDExitTzdataInitializationFailed: "failed to locate tzdata",
+	// EXIT_RESOURCES_TOO_LOW
+	ArangoDExitResourcesTooLow: "the system restricts resources below what is required to start arangod",
+	// EXIT_BINARY_NOT_FOUND
+	ArangoDExitBinaryNotFound: "binary not found",
+	// EXIT_COULD_NOT_BIND_PORT
+	ArangoDExitCouldNotBindPort: "port blocked",
+}

--- a/service/runner_docker.go
+++ b/service/runner_docker.go
@@ -107,13 +107,13 @@ func (r *dockerRunner) GetContainerDir(hostDir, defaultContainerDir string) stri
 	return defaultContainerDir
 }
 
-func (p *dockerContainer) WaitCh() <-chan struct{} {
-	c := make(chan struct{})
+func (p *dockerContainer) WaitCh() <-chan int {
+	c := make(chan int)
 
 	go func() {
 		defer close(c)
 
-		p.Wait()
+		c <- p.Wait()
 	}()
 
 	return c

--- a/service/runner_process.go
+++ b/service/runner_process.go
@@ -64,13 +64,13 @@ func getLockFilePath(serverDir string) string {
 	return filepath.Join(serverDir, "data", "LOCK")
 }
 
-func (p *process) WaitCh() <-chan struct{} {
-	c := make(chan struct{})
+func (p *process) WaitCh() <-chan int {
+	c := make(chan int)
 
 	go func() {
 		defer close(c)
 
-		p.Wait()
+		c <- p.Wait()
 	}()
 
 	return c

--- a/test/docker_check_exitcodes_test.go
+++ b/test/docker_check_exitcodes_test.go
@@ -1,0 +1,79 @@
+//
+// DISCLAIMER
+//
+// Copyright 2017-2022 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestDockerErrExitCodeHandler runs in 'single' mode with invalid ArangoD configuration and
+// checks that exit code is recognized by starter
+func TestDockerErrExitCodeHandler(t *testing.T) {
+	needTestMode(t, testModeDocker)
+	needStarterMode(t, starterModeSingle)
+	if os.Getenv("IP") == "" {
+		t.Fatal("IP envvar must be set to IP address of this machine")
+	}
+
+	volID := createDockerID("vol-starter-test-single-")
+	createDockerVolume(t, volID)
+	defer removeDockerVolume(t, volID)
+
+	// Cleanup of left over tests
+	removeDockerContainersByLabel(t, "starter-test=true")
+	removeStarterCreatedDockerContainers(t)
+
+	cID := createDockerID("starter-test-single-")
+	dockerRun := Spawn(t, strings.Join([]string{
+		"docker run -i",
+		"--label starter-test=true",
+		"--name=" + cID,
+		"--rm",
+		createLicenseKeyOption(),
+		fmt.Sprintf("-p %d:%d", basePort, basePort),
+		fmt.Sprintf("-v %s:/data", volID),
+		"-v /var/run/docker.sock:/var/run/docker.sock",
+		"arangodb/arangodb-starter",
+		"--docker.container=" + cID,
+		"--starter.address=$IP",
+		"--starter.mode=single",
+		"--args.all.config=invalidvalue",
+		createEnvironmentStarterOptions(),
+	}, " "))
+	defer dockerRun.Close()
+	defer removeDockerContainer(t, cID)
+
+	re := regexp.MustCompile("has failed 1 times, giving up")
+	require.NoError(t, dockerRun.ExpectTimeout(context.Background(), time.Second*20, re, ""))
+
+	require.NoError(t, dockerRun.WaitTimeout(time.Second*10), "Starter is not stopped in time")
+
+	waitForCallFunction(t,
+		ShutdownStarterCall(insecureStarterEndpoint(0*portIncrement)))
+}

--- a/test/process_check_exitcodes_test.go
+++ b/test/process_check_exitcodes_test.go
@@ -1,0 +1,52 @@
+//
+// DISCLAIMER
+//
+// Copyright 2017-2022 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+
+package test
+
+import (
+	"context"
+	"os"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestProcessErrExitCodeHandler runs in 'single' mode with invalid ArangoD configuration and
+// checks that exit code is recognized by starter
+func TestProcessErrExitCodeHandler(t *testing.T) {
+	removeArangodProcesses(t)
+	needTestMode(t, testModeProcess)
+	needStarterMode(t, starterModeSingle)
+	dataDir := SetUniqueDataDir(t)
+	defer os.RemoveAll(dataDir)
+
+	child := Spawn(t, "${STARTER} --starter.mode=single --args.all.config=invalidvalue "+createEnvironmentStarterOptions())
+	defer child.Close()
+
+	re := regexp.MustCompile("has failed 1 times, giving up")
+	require.NoError(t, child.ExpectTimeout(context.Background(), time.Second*20, re, ""))
+
+	if isVerbose {
+		t.Log("Waiting for termination")
+	}
+	require.NoError(t, child.WaitTimeout(time.Second*10), "Starter is not stopped in time")
+}


### PR DESCRIPTION
As mentioned in #99
Do not try to restart instance if exit code is unrecoverable.

This PR does not improve situation when user provided an invalid CLI option via passthrough option, e.g. `--args.all.invalid-flag=true`. ArangoD returns a general exit code 1 which is not enough to distinct if this is unrecoverable error.
