### PR TITLE
Fix goroutines/memory leak in test code

### DIFF
--- a/test/server_util.go
+++ b/test/server_util.go
@@ -274,8 +274,9 @@ func testArangodReachable(t *testing.T, sp client.ServerProcess, timeout time.Du
 	start := time.Now()
 	for {
 		url := fmt.Sprintf("%s://%s:%d/_api/version", scheme, sp.IP, sp.Port)
-		_, err := httpClient.Get(url)
+		resp, err := httpClient.Get(url)
 		if err == nil {
+			resp.Body.Close()
 			return
 		}
 		if timeout == 0 || time.Since(start) > timeout {
@@ -297,8 +298,9 @@ func testArangoSyncReachable(t *testing.T, sp client.ServerProcess, timeout time
 			t.Fatalf("NewRequest failed: %s", describe(err))
 		}
 		req.Header.Set("Authorization", "bearer "+syncMonitoringToken)
-		_, err = httpClient.Do(req)
+		resp, err := httpClient.Do(req)
 		if err == nil {
+			resp.Body.Close()
 			return
 		}
 		if timeout == 0 || time.Since(start) > timeout {

--- a/test/util.go
+++ b/test/util.go
@@ -299,8 +299,9 @@ func ServiceReadyCheckDatabase(databaseName string) ServiceReadyCheckFunc {
 
 func WaitForHttpPortClosed(log Logger, throttle Throttle, url string) TimeoutFunc {
 	return func() error {
-		_, err := http.Get(url)
+		resp, err := http.Get(url)
 		if err == nil {
+			resp.Body.Close()
 			throttle.Execute(func() {
 				log.Log("Got empty response")
 			})


### PR DESCRIPTION
For example, see this test run: https://app.travis-ci.com/github/arangodb-helper/arangodb/jobs/577774536/config

The http responses weren't handled properly.
