### PR TITLE
Fix WaitUntilStarterReady function

### DIFF
--- a/test/util.go
+++ b/test/util.go
@@ -196,8 +196,8 @@ func WaitUntilStarterReady(t *testing.T, what string, requiredGoodResults int, s
 		}
 	}
 
-	if failed <= requiredGoodResults {
-		GetLogger(t).Log("Starter Started")
+	if failed < requiredGoodResults || requiredGoodResults == 0 {
+		GetLogger(t).Log("%d starters started", len(starters)-failed)
 		return true
 	}
 


### PR DESCRIPTION
it must not return true if number of failed starters == requiredGoodResult