### PR TITLE
Fix LimitedBuffer Write(): out of index error

### DIFF
--- a/pkg/utils/buffer.go
+++ b/pkg/utils/buffer.go
@@ -57,8 +57,8 @@ func (b *LimitedBuffer) Write(p []byte) (n int, err error) {
 		if newLength <= b.limit {
 			b.buf = append(b.buf, p...)
 		} else {
-			truncateIndex := newLength - b.limit - 1
-			b.buf = append(b.buf[truncateIndex-1:], p...)
+			truncateIndex := newLength - b.limit
+			b.buf = append(b.buf[truncateIndex:], p...)
 		}
 	}
 	return gotLen, nil

--- a/pkg/utils/buffer_test.go
+++ b/pkg/utils/buffer_test.go
@@ -62,6 +62,22 @@ func TestCaptureWriter(t *testing.T) {
 		assert.Equal(t, "1234567890", cw.String())
 	})
 
+	t.Run("one-byte-overflow-1", func(t *testing.T) {
+		cw := NewLimitedBuffer(10)
+
+		_, _ = cw.Write([]byte(strings.Repeat("001234", 1)))
+		_, _ = cw.Write([]byte(strings.Repeat("56789", 1)))
+		assert.Equal(t, strings.Repeat("0123456789", 1), cw.String())
+	})
+
+	t.Run("one-byte-overflow-2", func(t *testing.T) {
+		cw := NewLimitedBuffer(10)
+
+		_, _ = cw.Write([]byte(strings.Repeat("00123", 1)))
+		_, _ = cw.Write([]byte(strings.Repeat("456789", 1)))
+		assert.Equal(t, strings.Repeat("0123456789", 1), cw.String())
+	})
+
 	t.Run("overflow-many", func(t *testing.T) {
 		cw := NewLimitedBuffer(100)
 


### PR DESCRIPTION
The problem was introduced in #317, so no updates in CHANGELOG