### PR TITLE
Add info on checking DC2DC synchronisation status

### DIFF
--- a/examples/local-sync/README.md
+++ b/examples/local-sync/README.md
@@ -85,3 +85,13 @@ arangosync get status \
     --auth.keyfile=${CERTDIR}/client-auth-ca.keyfile \
     --verbose
 ```
+
+## Step 5: Check the status of synchronization for each shard
+
+Target DC endpoint should be specified:
+```
+arangosync check sync \
+    --master.endpoint=https://${IP}:9542 \
+    --auth.keyfile=${CERTDIR}/client-auth-ca.keyfile \
+    --verbose
+```


### PR DESCRIPTION
`check sync` command was added a couple of years ago, the example wasn't updated. Running it gives more useful info for end-user compared to `get status`.