### PR TITLE
Rename CLI flag option 'config' to 'configuration' and allow value 'none'

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ Additional servers can be added in the same way.
 ## Using the config file to provide CLI options
 
 Starter looks for `arangodb-starter.conf` in working directory by default.
-You can specify the config file path using `--config` CLI option:
+You can specify the config file path using `--configuration` (`-c`)  CLI option:
 ```bash
-arangodb --config=/etc/arangodb-starter.conf
+arangodb --configuration=/etc/arangodb-starter.conf
 ```
 
 `.conf` files for ArangoDB Starter are in a simple key-value pair format. 

--- a/config.go
+++ b/config.go
@@ -23,6 +23,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
@@ -89,8 +90,13 @@ func trySetFlagFromConfig(flagName string, k *ini.Key, flagSets ...*pflag.FlagSe
 
 // loadFlagValuesFromConfig loads config and assigns its values to flag set (only if flag value wasn't changed before)
 func loadFlagValuesFromConfig(cfgFilePath string, fs, persistentFs *pflag.FlagSet) {
+	if strings.ToLower(cfgFilePath) == "none" {
+		// Skip loading: special value to ignore config
+		return
+	}
+
 	configFile, err := loadCfgFromFile(cfgFilePath)
-	if err != nil || configFile == nil && configFilePath != defaultConfigFilePath {
+	if err != nil || configFile == nil && cfgFilePath != defaultConfigFilePath {
 		log.Fatal().Err(err).Msgf("Could not load config file %s", cfgFilePath)
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -128,7 +128,7 @@ func init() {
 
 	pf := cmdMain.PersistentFlags()
 	pf.BoolVar(&showVersion, "version", false, "If set, show version and exit")
-	pf.StringVarP(&configFilePath, "config", "c", defaultConfigFilePath, "Config file path")
+	pf.StringVarP(&configFilePath, "configuration", "c", defaultConfigFilePath, "Configuration file path")
 
 	pf.BoolVar(&opts.log.verbose, "log.verbose", false, "Turn on debug logging")
 	pf.BoolVar(&opts.log.console, "log.console", true, "Send log output to console")

--- a/test/process_config_test.go
+++ b/test/process_config_test.go
@@ -42,7 +42,7 @@ func TestProcessConfigFileLoading(t *testing.T) {
 		dataDir := SetUniqueDataDir(t)
 		defer os.RemoveAll(dataDir)
 
-		child := Spawn(t, "${STARTER} --config=test/testdata/thisfiledoesnoexist.conf")
+		child := Spawn(t, "${STARTER} --configuration=test/testdata/thisfiledoesnoexist.conf")
 		defer child.Close()
 
 		WaitUntilStarterExit(t, 15*time.Second, 1, child)
@@ -52,7 +52,7 @@ func TestProcessConfigFileLoading(t *testing.T) {
 		dataDir := SetUniqueDataDir(t)
 		defer os.RemoveAll(dataDir)
 
-		child := Spawn(t, "${STARTER} --config=test/testdata/invalidkeys.conf")
+		child := Spawn(t, "${STARTER} --configuration=test/testdata/invalidkeys.conf")
 		defer child.Close()
 
 		WaitUntilStarterExit(t, 15*time.Second, 1, child)
@@ -62,17 +62,28 @@ func TestProcessConfigFileLoading(t *testing.T) {
 		dataDir := SetUniqueDataDir(t)
 		defer os.RemoveAll(dataDir)
 
-		child := Spawn(t, "${STARTER} --config=test/testdata/invalidvalues.conf")
+		child := Spawn(t, "${STARTER} --configuration=test/testdata/invalidvalues.conf")
 		defer child.Close()
 
 		WaitUntilStarterExit(t, 15*time.Second, 1, child)
+	})
+
+	t.Run("none", func(t *testing.T) {
+		dataDir := SetUniqueDataDir(t)
+		defer os.RemoveAll(dataDir)
+
+		child := Spawn(t, "${STARTER} --configuration=noNe --starter.mode=single")
+		defer child.Close()
+
+		require.True(t, WaitUntilStarterReady(t, whatSingle, 1, child))
+		SendIntrAndWait(t, child)
 	})
 
 	t.Run("plain", func(t *testing.T) {
 		dataDir := SetUniqueDataDir(t)
 		defer os.RemoveAll(dataDir)
 
-		child := Spawn(t, "${STARTER} --config=test/testdata/single.conf")
+		child := Spawn(t, "${STARTER} --configuration=test/testdata/single.conf")
 		defer child.Close()
 
 		require.True(t, WaitUntilStarterReady(t, whatSingle, 1, child))
@@ -83,7 +94,7 @@ func TestProcessConfigFileLoading(t *testing.T) {
 		dataDir := SetUniqueDataDir(t)
 		defer os.RemoveAll(dataDir)
 
-		child := Spawn(t, "${STARTER} --starter.mode=single --config=test/testdata/activefailover.conf")
+		child := Spawn(t, "${STARTER} --starter.mode=single --configuration=test/testdata/activefailover.conf")
 		defer child.Close()
 
 		require.True(t, WaitUntilStarterReady(t, whatSingle, 1, child))
@@ -94,7 +105,7 @@ func TestProcessConfigFileLoading(t *testing.T) {
 		dataDir := SetUniqueDataDir(t)
 		defer os.RemoveAll(dataDir)
 
-		child := Spawn(t, "${STARTER} --config=test/testdata/single-sections.conf")
+		child := Spawn(t, "${STARTER} --configuration=test/testdata/single-sections.conf")
 		defer child.Close()
 
 		require.True(t, WaitUntilStarterReady(t, whatSingle, 1, child))


### PR DESCRIPTION
Now it will match the behaviour of other tools