### PR TITLE
Improve detection of arangod binary when running local installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [master](https://github.com/arangodb-helper/arangodb/tree/master) (N/A)
 - Improve deprecated notice for old passthrough flags
+- Improve detection of arangod binary when running local installation
 
 ## [0.15.6](https://github.com/arangodb-helper/arangodb/tree/0.15.6) (2023-01-20)
 - Fix restarting cluster with arangosync enabled


### PR DESCRIPTION
Starter will check for local relative paths first, then system-wide default paths.

Closes #268 
Closes https://github.com/arangodb/arangodb/issues/9996
Closes https://github.com/arangodb/arangodb/issues/18052
