### PR TITLE
GT-330 Remove `netgo` build tag for Windows to disable new Go resolver behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Improve deprecated notice for old passthrough flags
 - Improve detection of arangod binary when running local installation (use --server.use-local-bin)
 - Upgrade base Alpine image and Go dependencies to fix CVEs
+- Remove `netgo` build tag for Windows to disable new Go resolver behaviour: https://github.com/golang/go/issues/57757
 
 ## [0.15.6](https://github.com/arangodb-helper/arangodb/tree/0.15.6) (2023-01-20)
 - Fix restarting cluster with arangosync enabled

--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,11 @@ binaries-test:
 
 $(BIN): $(GOBUILDDIR) $(GO_SOURCES)
 	@mkdir -p $(BINDIR)
+ifeq ($(GOOS),windows)
+	$(DOCKER_CMD) go build -ldflags "-X main.projectVersion=$(VERSION) -X main.projectBuild=$(COMMIT)" -o "$(BUILD_BIN)" .
+else
 	$(DOCKER_CMD) go build -installsuffix netgo -tags netgo -ldflags "-X main.projectVersion=$(VERSION) -X main.projectBuild=$(COMMIT)" -o "$(BUILD_BIN)" .
+endif
 
 $(TESTBIN): $(GOBUILDDIR) $(TEST_SOURCES) $(BIN)
 	@mkdir -p $(BINDIR)


### PR DESCRIPTION
 In go1.19 there is no support for 'hosts' file for Windows:
 https://github.com/golang/go/issues/57757

 Disabling netgo will revert behaviour to go1.18 for resolving names.

Fixes `Failed to connect to master error="Get \"http://localhost:9528/hello\": dial tcp: lookup localhost on 10.156.0.1:53: no such host"` error