### PR TITLE
GT-363 Improve ArangoDB version detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # ArangoDB Starter Changelog
 
 ## [master](https://github.com/arangodb-helper/arangodb/tree/master) (N/A)
+- Improve ArangoDB version detection
 
 ## [0.15.7](https://github.com/arangodb-helper/arangodb/tree/0.15.7) (2023-02-17)
 - Improve deprecated notice for old passthrough flags

--- a/service/version_check.go
+++ b/service/version_check.go
@@ -26,9 +26,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/dchest/uniuri"
 	"strings"
 	"time"
+
+	"github.com/dchest/uniuri"
 
 	"github.com/arangodb/go-driver"
 

--- a/service/version_check.go
+++ b/service/version_check.go
@@ -49,6 +49,10 @@ func (s *Service) DatabaseVersion(ctx context.Context) (driver.Version, bool, er
 			return v, enterprise, nil
 		}
 
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return "", false, ctxErr
+		}
+
 		s.log.Warn().Err(err).Msgf("Error while getting version. Attempt %d of %d", i+1, retries)
 		time.Sleep(time.Second)
 	}


### PR DESCRIPTION
`log.force-direct` option forces arangod to write output using main thread - ensuring the whole log output will be flushed before return

Also some refactoring of DatabaseVersion to improve readability.

The retry logic probably can be deleted, but let's wait if this warning will disappear completely.