### PR TITLE
Add --docker.force-bind-ports option to add ports for custom networks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # ArangoDB Starter Changelog
 
 ## [master](https://github.com/arangodb-helper/arangodb/tree/master) (N/A)
+- Add --docker.force-bind-ports option to add ports for custom networks
 
 ## [0.15.8](https://github.com/arangodb-helper/arangodb/tree/0.15.8) (2023-06-02)
 - Add passing ARANGODB_SERVER_DIR env variable when starting arangod instances

--- a/main.go
+++ b/main.go
@@ -188,6 +188,7 @@ func init() {
 	f.BoolVar(&opts.docker.netHost, "docker.net-host", false, "Run containers with --net=host")
 	f.Lookup("docker.net-host").Deprecated = "use --docker.net-mode=host instead"
 	f.StringVar(&opts.docker.networkMode, "docker.net-mode", "", "Run containers with --net=<value>")
+	f.BoolVar(&opts.docker.forceBindPorts, "docker.force-bind-ports", false, "If true, container will publish ports even on custom Docker network")
 	f.BoolVar(&opts.docker.privileged, "docker.privileged", false, "Run containers with --privileged")
 	f.BoolVar(&opts.docker.tty, "docker.tty", true, "Run containers with TTY enabled")
 
@@ -732,6 +733,7 @@ func mustPrepareService(generateAutoKeyFile bool) (*service.Service, service.Boo
 		DockerUser:              opts.docker.user,
 		DockerGCDelay:           opts.docker.gcDelay,
 		DockerNetworkMode:       opts.docker.networkMode,
+		DockerForceBindPorts:    opts.docker.forceBindPorts,
 		DockerPrivileged:        opts.docker.privileged,
 		DockerTTY:               opts.docker.tty,
 		ProjectVersion:          projectVersion,

--- a/options.go
+++ b/options.go
@@ -95,6 +95,7 @@ type starterOptions struct {
 		gcDelay         time.Duration
 		netHost         bool // Deprecated
 		networkMode     string
+		forceBindPorts  bool
 		privileged      bool
 		tty             bool
 	}

--- a/service/service.go
+++ b/service/service.go
@@ -91,6 +91,7 @@ type Config struct {
 	DockerUser            string
 	DockerGCDelay         time.Duration
 	DockerNetworkMode     string
+	DockerForceBindPorts  bool
 	DockerPrivileged      bool
 	DockerTTY             bool
 	RunningInDocker       bool
@@ -164,7 +165,7 @@ func (c Config) CreateRunner(log zerolog.Logger) (Runner, Config, bool) {
 	if c.UseDockerRunner() {
 		runner, err := NewDockerRunner(log, c.DockerEndpoint, c.DockerArangodImage, c.DockerArangoSyncImage,
 			c.DockerImagePullPolicy, c.DockerUser, c.DockerContainerName,
-			c.DockerGCDelay, c.DockerNetworkMode, c.DockerPrivileged, c.DockerTTY)
+			c.DockerGCDelay, c.DockerNetworkMode, c.DockerForceBindPorts, c.DockerPrivileged, c.DockerTTY)
 		if err != nil {
 			log.Fatal().Err(err).Msg("Failed to create docker runner")
 		}


### PR DESCRIPTION
@ajanikow I've implemented it as CLI option, but let me know if it should be a feature flag.