### PR TITLE
Fix context handling in WaitUntilStarterReady for tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # ArangoDB Starter Changelog
 
 ## [master](https://github.com/arangodb-helper/arangodb/tree/master) (N/A)
+- Fix context handling in WaitUntilStarterReady for tests
 
 ## [0.15.8](https://github.com/arangodb-helper/arangodb/tree/0.15.8) (2023-06-02)
 - Add passing ARANGODB_SERVER_DIR env variable when starting arangod instances

--- a/test/util.go
+++ b/test/util.go
@@ -201,9 +201,7 @@ func WaitUntilStarterReady(t *testing.T, what string, requiredGoodResults int, s
 	for id, starter := range starters {
 		go func(i int, s *SubProcess) {
 			defer wg.Done()
-			defer cancel()
 			id := fmt.Sprintf("starter-%d", i+1)
-
 			results[i] = s.ExpectTimeout(ctx, time.Minute*3, regexp.MustCompile(fmt.Sprintf("Your %s can now be accessed with a browser at", what)), id)
 		}(id, starter)
 	}

--- a/test/util.go
+++ b/test/util.go
@@ -215,8 +215,9 @@ func WaitUntilStarterReady(t *testing.T, what string, requiredGoodResults int, s
 		}
 	}
 
-	if failed < requiredGoodResults || requiredGoodResults == 0 {
-		GetLogger(t).Log("%d starters started", len(starters)-failed)
+	readyStarters := len(starters) - failed
+	if readyStarters >= requiredGoodResults || requiredGoodResults == 0 {
+		GetLogger(t).Log("%d starters ready", readyStarters)
 		return true
 	}
 
@@ -228,7 +229,9 @@ func WaitUntilStarterReady(t *testing.T, what string, requiredGoodResults int, s
 		}
 	}
 	for _, msg := range results {
-		t.Error(msg)
+		if msg != nil {
+			t.Error(msg)
+		}
 	}
 
 	return false


### PR DESCRIPTION
context was canceled too early (before all goroutines finished)