### PR TITLE
Change INF level to WRN or ERR when child process terminated with non-zero code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [master](https://github.com/arangodb-helper/arangodb/tree/master) (N/A)
 - Retry server upgrade if requested by exit code (EXIT_UPGRADE_REQUIRED)
 - Fix possible deadlock and goroutine leak while waiting for child process termination
+- Change INF level to WRN or ERR when child process terminated with non-zero
 
 ## [1.16.0](https://github.com/arangodb-helper/arangodb/tree/1.16.0) (2023-07-21)
 - Add sanity check for pass-through args usage


### PR DESCRIPTION
- if process exited without signal or signal was SIGSTOP/SIGCONT then log level would be warning
- otherwise it is ERR