### PR TITLE
Redirect HTTP server warnings into log file, skip TLS handshake errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # ArangoDB Starter Changelog
 
 ## [master](https://github.com/arangodb-helper/arangodb/tree/master) (N/A)
+- Redirect HTTP server warnings into log file, skip TLS handshake errors
 
 ## [v0.17.2](https://github.com/arangodb-helper/arangodb/tree/0.17.2) (2023-11-23)
 - Bump Go version (1.21.4) and dependencies for CVE fixes

--- a/pkg/logging/adapter.go
+++ b/pkg/logging/adapter.go
@@ -1,0 +1,49 @@
+//
+// DISCLAIMER
+//
+// Copyright 2017-2023 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+
+package logging
+
+import (
+	"io"
+	goLog "log"
+	"strings"
+
+	"github.com/rs/zerolog"
+)
+
+// logAdapter is used as an adapter for standard go logged
+type logAdapter zerolog.Logger
+
+var (
+	_ io.Writer = logAdapter{}
+)
+
+func (l logAdapter) Write(p []byte) (int, error) {
+	line := strings.TrimSpace(string(p))
+	if !strings.Contains(line, "TLS handshake error") {
+		log := zerolog.Logger(l)
+		log.Error().Msg(line)
+	}
+	return len(p), nil
+}
+
+func NewAdapter(l zerolog.Logger) *goLog.Logger {
+	return goLog.New(logAdapter(l), "", 0)
+}

--- a/service/server.go
+++ b/service/server.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/rs/zerolog"
 
+	"github.com/arangodb-helper/arangodb/pkg/logging"
 	driver "github.com/arangodb/go-driver"
 
 	"github.com/arangodb-helper/arangodb/client"
@@ -124,7 +125,9 @@ func newHTTPServer(log zerolog.Logger, context httpServerContext, runtimeServerM
 	return &httpServer{
 		log:     log,
 		context: context,
-		server:  &http.Server{},
+		server: &http.Server{
+			ErrorLog: logging.NewAdapter(log.With().Str("logger", "http-server").Logger()),
+		},
 		idInfo: client.IDInfo{
 			ID: serverID,
 		},


### PR DESCRIPTION
1) Force underlying Go packages to write to zerolog instead of stderr
2) `TLS handshake error from` can spam a lot, especially when connecting through many intermediate proxies. Remove this from output.

Adapted from arangosync implementation.