### PR TITLE
Docker: CE equals EE in ArangoDB v3.12.5+

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,6 @@ ENV DATA_DIR=/data
 ENV RUNNING_IN_DOCKER=true
 
 # Docker image containing arangod.
-ENV DOCKER_IMAGE=arangodb/arangodb:latest
+ENV DOCKER_IMAGE=arangodb/enterprise:latest
 
 ENTRYPOINT ["/app/arangodb"]

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ DOCKERCLI ?= $(shell which docker)
 DOCKER_PLATFORMS ?= linux/amd64,linux/arm64
 DOCKER_BUILD_CLI := $(DOCKERCLI) build --build-arg "IMAGE=$(ALPINE_IMAGE)" --platform $(DOCKER_PLATFORMS)
 
-ARANGODB ?= arangodb/arangodb:latest
+ARANGODB ?= arangodb/enterprise:latest
 
 TEST_TIMEOUT := 1h
 

--- a/examples/mac_on_docker_cluster.sh
+++ b/examples/mac_on_docker_cluster.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# This exampe shows how to run an ArangoDB cluster all locally in docker on mac.
+# This example shows how to run an ArangoDB cluster all locally in docker on mac.
 # 
 # By default this script uses the latest released ArangoDB docker image.
 # To use another image, set ARANGOIMAGE to the desired image, before calling this script.
@@ -11,7 +11,7 @@
 
 NSCONTAINER=arangodb-on-mac-ns 
 STARTERCONTAINER=arangodb-on-mac
-ARANGOIMAGE=${ARANGOIMAGE:=arangodb/arangodb:latest}
+ARANGOIMAGE=${ARANGOIMAGE:=arangodb/enterprise:latest}
 
 # Create network namespace container.
 # Make sure to expose all ports you want here.


### PR DESCRIPTION
`arangodb/arangodb` images are no longer published, use `arangodb/enterprise` instead

Is this change a problem for older versions, like accidentally switching from CE to EE?